### PR TITLE
Add Vagrantfile for module testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,39 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant::Config.run do |config|
+  config.vm.define :ls do |ls|
+    ls.vm.box        = "precise32"
+    ls.vm.host_name  = "ls"
+    ls.vm.customize    ["modifyvm", :id, "--memory", "1024"]
+    ls.vm.share_folder "module", 
+                       "/tmp/vagrant-puppet/modules/logstash", 
+                       ".", 
+                       :create => true
+    ls.ssh.max_tries = 150
+
+    # Upgrade Vagrant's inline Puppet to 3.x:
+    ls.vm.provision :shell do |shell|
+      shell.inline = "/opt/vagrant_ruby/bin/gem update puppet --no-ri --no-rdoc"
+    end
+
+    # Run apt-get update:
+    ls.vm.provision :shell do |shell|
+      shell.inline = "/usr/bin/apt-get update"
+    end
+
+    MANIFESTS = [
+      'vagrant-prereq.pp', # prerequisites, e.g. other Puppet modules
+      'vagrant.pp'         # the Logstash configuration we're testing
+    ]
+
+    # Run the Puppet provisioner for each manifest
+    for manifest in MANIFESTS
+      ls.vm.provision :puppet do |puppet|
+        puppet.manifests_path = "tests"
+        puppet.manifest_file = manifest
+        puppet.options = ["--modulepath", "/tmp/vagrant-puppet/modules"]
+      end
+    end
+  end
+end

--- a/tests/vagrant-prereq.pp
+++ b/tests/vagrant-prereq.pp
@@ -1,0 +1,14 @@
+$vpup = '/opt/vagrant_ruby/bin/puppet'
+$vmods = '/tmp/vagrant-puppet/modules'
+
+define vpupmod() {
+  $modulename = inline_template('<%= name.split("/")[1] %>')
+  exec { "install module ${name}":
+    command => "${vpup} module install ${name} --modulepath ${vmods}",
+    creates => "${vmods}/${modulename}",
+  }
+}
+
+vpupmod { 
+  'puppetlabs/stdlib':
+}

--- a/tests/vagrant.pp
+++ b/tests/vagrant.pp
@@ -1,0 +1,34 @@
+$jarbase     = 'https://logstash.objects.dreamhost.com/release'
+$jarfile     = 'logstash-1.1.9-monolithic.jar'
+$jarpath     = "/tmp/$jarfile"
+$jdk         = 'openjdk-7-jre-headless'
+$installpath = '/opt/logstash'
+
+package { 'curl':
+  ensure => present,
+}
+
+package { $jdk:
+  ensure => present,
+}
+
+exec { 'get-jarfile':
+  command => "/usr/bin/curl -L ${jarbase}/${jarfile} -o ${jarpath}",
+  creates => $jarpath,
+  require => Package['curl'],
+}
+
+file { $installpath:
+  ensure => directory,
+  owner  => root,
+  group  => root,
+  mode   => '0755',
+}
+
+class { 'logstash':
+  jarfile     => $jarpath,
+  provider    => 'custom',
+  installpath => $installpath,
+  require     => [Exec['get-jarfile'], Package[$jdk], File[$installpath]],
+}
+


### PR DESCRIPTION
To find out whether the `init.d` script provider works as intended on Ubuntu:

```
vagrant up
```

This'll come in especially handy when testing multiple instance support: just extend the `vagrant.pp` file to add both log-gathering and log-indexing instances. I'd stick with the embedded ElasticSearch. 

I've tested adding [thomasvandoren/redis](http://forge.puppetlabs.com/thomasvandoren/redis) to the `vagrant-prereqs.pp` file: it works fine.

```
 vpupmod {
  'puppetlabs/stdlib':;
  'thomasvandoren/redis':;
}
```
