### PR TITLE
Link logstash.jar file properly when provision by jar

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -97,7 +97,7 @@ class logstash::package {
       require => Exec['create_install_dir']
     }
     file { "${logstash::installpath}/logstash.jar":
-      ensure  => present,
+      ensure  => 'link',
       target  => "${logstash::installpath}/${basefilename}",
       require => File["${logstash::installpath}/${basefilename}"]
     }


### PR DESCRIPTION
changing logstash.jar to link: when I provision as-is, a blank file is created, rather than a link. ensure => 'link' brings it up correctly.
