### PR TITLE
Apply the correct Puppet URI scheme based on Puppet offical doc

### DIFF
--- a/manifests/servicefile.pp
+++ b/manifests/servicefile.pp
@@ -76,7 +76,7 @@ define logstash::servicefile (
     if $def_file {
       $defaults_file = $def_file
     } else {
-      $defaults_file = "puppet:///${module_name}/etc/sysconfig/logstash.defaults"
+      $defaults_file = "puppet:///modules/${module_name}/etc/sysconfig/logstash.defaults"
     }
 
     # Write service file


### PR DESCRIPTION
Based on [http://docs.puppetlabs.com/references/latest/type.html](http://docs.puppetlabs.com/references/latest/type.html)
the Puppet URI scheme is  `puppet:///modules/name_of_module/filename`
while in the module it was `puppet://name_of_module/filename`
