### PR TITLE
allow puppet >= 3.0 databindings for class params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@ class logstash(
   $version       = false,
   $provider      = 'package',
   $jarfile       = undef,
-  $installpath   = hiera('logstash::installpath', $logstash::params::installpath),
+  $installpath   = '',
   $java_install  = false,
   $java_package  = undef,
   $instances     = [ 'agent' ],
@@ -111,6 +111,19 @@ class logstash(
 
   if $initfiles {
     validate_hash($initfiles)
+  }
+
+  if $install_path == '' {
+    case $::operatingsystem {
+      'RedHat', 'CentOS', 'Fedora', 'Scientific', 'RedHat', 'Amazon': {
+        $installpath_real = '/usr/share/logstash'
+      }
+      'Debian', 'Ubuntu': {
+        $installpath_real = '/var/lib/logstash'
+      }
+    }
+  } else {
+    $installpath_real = $install_path
   }
 
   #### Manage actions

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -68,7 +68,7 @@ class logstash::package {
       fail('logstash needs jarfile argument when using custom provider')
     }
 
-    if $logstash::installpath == undef {
+    if $logstash::installpath_real == undef {
       fail('logstash need installpath argument when using custom provider')
     }
 
@@ -76,8 +76,8 @@ class logstash::package {
     exec { 'create_install_dir':
       cwd     => '/',
       path    => ['/usr/bin', '/bin'],
-      command => "mkdir -p ${logstash::installpath}",
-      creates => $logstash::installpath;
+      command => "mkdir -p ${logstash::installpath_real}",
+      creates => $logstash::installpath_real;
     }
 
     # Create log directory
@@ -91,16 +91,16 @@ class logstash::package {
     # Place the jar file
     $filenameArray = split($logstash::jarfile, '/')
     $basefilename = $filenameArray[-1]
-    file { "${logstash::installpath}/${basefilename}":
+    file { "${logstash::installpath_real}/${basefilename}":
       ensure  => present,
       source  => $logstash::jarfile,
       require => Exec['create_install_dir'],
       backup  => false
     }
-    file { "${logstash::installpath}/logstash.jar":
+    file { "${logstash::installpath_real}/logstash.jar":
       ensure  => 'link',
-      target  => "${logstash::installpath}/${basefilename}",
-      require => File["${logstash::installpath}/${basefilename}"],
+      target  => "${logstash::installpath_real}/${basefilename}",
+      require => File["${logstash::installpath_real}/${basefilename}"],
       backup  => false
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,12 +46,10 @@ class logstash::params {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'RedHat', 'Amazon': {
       # main application
       $package     = [ 'logstash' ]
-      $installpath = '/usr/share/logstash'
     }
     'Debian', 'Ubuntu': {
       # main application
       $package     = [ 'logstash' ]
-      $installpath = '/var/lib/logstash'
     }
     default: {
       fail("\"${module_name}\" provides no package default value


### PR DESCRIPTION
Using the params class doesn't easily allow puppet 3 hiera data bindings.  Move variables with no logic into init.pp as defaults, add hiera lookup for remaining parameter with a default to params.
