### PR TITLE
Debian use tmpdir created by logstash::config

### DIFF
--- a/templates/etc/init.d/logstash.init.Debian.erb
+++ b/templates/etc/init.d/logstash.init.Debian.erb
@@ -42,7 +42,7 @@ JAVA=/usr/bin/java
 LS_HOME=<%= scope.lookupvar('logstash::installpath') %>
 
 # Additional Java OPTS
-LS_JAVA_OPTS=" -Djava.io.tmpdir=/var/logstash/"
+LS_JAVA_OPTS=" -Djava.io.tmpdir=$LS_HOME/tmp"
 
 # logstash log directory
 LOG_DIR=/var/log/logstash


### PR DESCRIPTION
The previous value of `/var/logstash` wasn't created by the module. Now
matches the behaviour on RHEL.
