### PR TITLE
Add support for gauge metric type in statsd output plugin

### DIFF
--- a/manifests/output/statsd.pp
+++ b/manifests/output/statsd.pp
@@ -269,7 +269,7 @@ define logstash::output::statsd (
 
   file { $conffiles:
     ensure  => present,
-    content => "output {\n statsd {\n${opt_count}${opt_gauge${opt_debug}${opt_decrement}${opt_exclude_tags}${opt_fields}${opt_host}${opt_increment}${opt_namespace}${opt_port}${opt_sample_rate}${opt_sender}${opt_tags}${opt_timing}${opt_type} }\n}\n",
+    content => "output {\n statsd {\n${opt_count}${opt_gauge}${opt_debug}${opt_decrement}${opt_exclude_tags}${opt_fields}${opt_host}${opt_increment}${opt_namespace}${opt_port}${opt_sample_rate}${opt_sender}${opt_tags}${opt_timing}${opt_type} }\n}\n",
     mode    => '0440',
     notify  => Service[$services],
     require => Class['logstash::package', 'logstash::config']


### PR DESCRIPTION
Logstash have merged my pull request to add the functionality upstream so this should be consumable now.
