### PR TITLE
force removal of directories if ensure is absent

### DIFF
--- a/manifests/configdir.pp
+++ b/manifests/configdir.pp
@@ -65,10 +65,12 @@ define logstash::configdir {
         file { $config_dir :
             ensure  => 'absent',
             recurse => 'true',
+            force   => 'true',
         }
         file { $sincedb_dir :
             ensure  => 'absent',
             recurse => 'true',
+            force   => 'true',
         }
 
   }


### PR DESCRIPTION
Without force=>true, this is what happens on a node which was ensure => present but has been changed to ensure => absent.

<pre>Jul 24 13:29:21 jid-dbs1 puppet-agent[29407]: (/Stage[main]/Logstash::Config/Logstash::Configdir[agent]/File[/etc/logstash/agent/sincedb]) Not removing directory; use 'force' to override
Jul 24 13:29:21 jid-dbs1 puppet-agent[29407]: (/Stage[main]/Logstash::Config/Logstash::Configdir[agent]/File[/etc/logstash/agent/sincedb]/ensure) removed
Jul 24 13:29:21 jid-dbs1 puppet-agent[29407]: (/Stage[main]/Logstash::Config/Logstash::Configdir[agent]/File[/etc/logstash/agent/config]) Not removing directory; use 'force' to override
Jul 24 13:29:21 jid-dbs1 puppet-agent[29407]: (/Stage[main]/Logstash::Config/Logstash::Configdir[agent]/File[/etc/logstash/agent/config]/ensure) removed
Jul 24 13:29:43 jid-dbs1 puppet-agent[29407]: Finished catalog run in 52.71 seconds</pre>

After setting these two file resources to force => true, here's what happens:
<pre>notice: /Stage[main]/Logstash::Config/Logstash::Configdir[agent]/File[/etc/logstash/agent/sincedb]/ensure: removed
notice: /Stage[main]/Logstash::Config/Logstash::Configdir[agent]/File[/etc/logstash/agent/config]/ensure: removed
notice: Finished catalog run in 60.36 seconds
</pre>


I'd prefer to remove the configuration and sincedb files.
