### PR TITLE
use "@var_x" rather than deprecated "var_x" in (inline) templates

### DIFF
--- a/manifests/filter/alter.pp
+++ b/manifests/filter/alter.pp
@@ -199,7 +199,7 @@ define logstash::filter::alter (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/anonymize.pp
+++ b/manifests/filter/anonymize.pp
@@ -175,7 +175,7 @@ define logstash::filter::anonymize (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/checksum.pp
+++ b/manifests/filter/checksum.pp
@@ -170,7 +170,7 @@ define logstash::filter::checksum (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/clone.pp
+++ b/manifests/filter/clone.pp
@@ -161,7 +161,7 @@ define logstash::filter::clone (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/csv.pp
+++ b/manifests/filter/csv.pp
@@ -187,7 +187,7 @@ define logstash::filter::csv (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/date.pp
+++ b/manifests/filter/date.pp
@@ -193,7 +193,7 @@ define logstash::filter::date (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/dns.pp
+++ b/manifests/filter/dns.pp
@@ -190,7 +190,7 @@ define logstash::filter::dns (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/environment.pp
+++ b/manifests/filter/environment.pp
@@ -154,14 +154,14 @@ define logstash::filter::environment (
   if ($add_field_from_env != '') {
     validate_hash($add_field_from_env)
     $var_add_field_from_env = $add_field_from_env
-    $arr_add_field_from_env = inline_template('<%= "["+var_add_field_from_env.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field_from_env = inline_template('<%= "["+@var_add_field_from_env.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field_from_env = "  add_field_from_env => ${arr_add_field_from_env}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/gelfify.pp
+++ b/manifests/filter/gelfify.pp
@@ -147,7 +147,7 @@ define logstash::filter::gelfify (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/geoip.pp
+++ b/manifests/filter/geoip.pp
@@ -186,7 +186,7 @@ define logstash::filter::geoip (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/grep.pp
+++ b/manifests/filter/grep.pp
@@ -190,14 +190,14 @@ define logstash::filter::grep (
   if ($match != '') {
     validate_hash($match)
     $var_match = $match
-    $arr_match = inline_template('<%= "["+var_match.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_match = inline_template('<%= "["+@var_match.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_match = "  match => ${arr_match}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/grok.pp
+++ b/manifests/filter/grok.pp
@@ -327,14 +327,14 @@ define logstash::filter::grok (
   if ($match != '') {
     validate_hash($match)
     $var_match = $match
-    $arr_match = inline_template('<%= "["+var_match.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_match = inline_template('<%= "["+@var_match.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_match = "  match => ${arr_match}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/grokdiscovery.pp
+++ b/manifests/filter/grokdiscovery.pp
@@ -147,7 +147,7 @@ define logstash::filter::grokdiscovery (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/json.pp
+++ b/manifests/filter/json.pp
@@ -168,7 +168,7 @@ define logstash::filter::json (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/kv.pp
+++ b/manifests/filter/kv.pp
@@ -224,7 +224,7 @@ define logstash::filter::kv (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/metrics.pp
+++ b/manifests/filter/metrics.pp
@@ -211,14 +211,14 @@ define logstash::filter::metrics (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 
   if ($timer != '') {
     validate_hash($timer)
     $var_timer = $timer
-    $arr_timer = inline_template('<%= "["+var_timer.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_timer = inline_template('<%= "["+@var_timer.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_timer = "  timer => ${arr_timer}\n"
   }
 

--- a/manifests/filter/multiline.pp
+++ b/manifests/filter/multiline.pp
@@ -228,7 +228,7 @@ define logstash::filter::multiline (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/mutate.pp
+++ b/manifests/filter/mutate.pp
@@ -292,56 +292,56 @@ define logstash::filter::mutate (
   if ($rename != '') {
     validate_hash($rename)
     $var_rename = $rename
-    $arr_rename = inline_template('<%= "["+var_rename.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_rename = inline_template('<%= "["+@var_rename.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_rename = "  rename => ${arr_rename}\n"
   }
 
   if ($replace != '') {
     validate_hash($replace)
     $var_replace = $replace
-    $arr_replace = inline_template('<%= "["+var_replace.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_replace = inline_template('<%= "["+@var_replace.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_replace = "  replace => ${arr_replace}\n"
   }
 
   if ($split != '') {
     validate_hash($split)
     $var_split = $split
-    $arr_split = inline_template('<%= "["+var_split.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_split = inline_template('<%= "["+@var_split.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_split = "  split => ${arr_split}\n"
   }
 
   if ($merge != '') {
     validate_hash($merge)
     $var_merge = $merge
-    $arr_merge = inline_template('<%= "["+var_merge.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_merge = inline_template('<%= "["+@var_merge.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_merge = "  merge => ${arr_merge}\n"
   }
 
   if ($join != '') {
     validate_hash($join)
     $var_join = $join
-    $arr_join = inline_template('<%= "["+var_join.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_join = inline_template('<%= "["+@var_join.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_join = "  join => ${arr_join}\n"
   }
 
   if ($convert != '') {
     validate_hash($convert)
     $var_convert = $convert
-    $arr_convert = inline_template('<%= "["+var_convert.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_convert = inline_template('<%= "["+@var_convert.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_convert = "  convert => ${arr_convert}\n"
   }
 
   if ($update != '') {
     validate_hash($update)
     $var_update = $update
-    $arr_update = inline_template('<%= "["+var_update.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_update = inline_template('<%= "["+@var_update.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_update = "  update => ${arr_update}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/noop.pp
+++ b/manifests/filter/noop.pp
@@ -146,7 +146,7 @@ define logstash::filter::noop (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/prune.pp
+++ b/manifests/filter/prune.pp
@@ -220,21 +220,21 @@ define logstash::filter::prune (
   if ($whitelist_values != '') {
     validate_hash($whitelist_values)
     $var_whitelist_values = $whitelist_values
-    $arr_whitelist_values = inline_template('<%= "["+var_whitelist_values.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_whitelist_values = inline_template('<%= "["+@var_whitelist_values.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_whitelist_values = "  whitelist_values => ${arr_whitelist_values}\n"
   }
 
   if ($blacklist_values != '') {
     validate_hash($blacklist_values)
     $var_blacklist_values = $blacklist_values
-    $arr_blacklist_values = inline_template('<%= "["+var_blacklist_values.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_blacklist_values = inline_template('<%= "["+@var_blacklist_values.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_blacklist_values = "  blacklist_values => ${arr_blacklist_values}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/ruby.pp
+++ b/manifests/filter/ruby.pp
@@ -163,7 +163,7 @@ define logstash::filter::ruby (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/sleep.pp
+++ b/manifests/filter/sleep.pp
@@ -189,7 +189,7 @@ define logstash::filter::sleep (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/split.pp
+++ b/manifests/filter/split.pp
@@ -166,7 +166,7 @@ define logstash::filter::split (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/syslog_pri.pp
+++ b/manifests/filter/syslog_pri.pp
@@ -196,7 +196,7 @@ define logstash::filter::syslog_pri (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/translate.pp
+++ b/manifests/filter/translate.pp
@@ -234,14 +234,14 @@ define logstash::filter::translate (
   if ($dictionary != '') {
     validate_hash($dictionary)
     $var_dictionary = $dictionary
-    $arr_dictionary = inline_template('<%= "["+var_dictionary.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_dictionary = inline_template('<%= "["+@var_dictionary.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_dictionary = "  dictionary => ${arr_dictionary}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/urldecode.pp
+++ b/manifests/filter/urldecode.pp
@@ -165,7 +165,7 @@ define logstash::filter::urldecode (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/useragent.pp
+++ b/manifests/filter/useragent.pp
@@ -174,7 +174,7 @@ define logstash::filter::useragent (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/filter/xml.pp
+++ b/manifests/filter/xml.pp
@@ -199,14 +199,14 @@ define logstash::filter::xml (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 
   if ($xpath != '') {
     validate_hash($xpath)
     $var_xpath = $xpath
-    $arr_xpath = inline_template('<%= "["+var_xpath.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_xpath = inline_template('<%= "["+@var_xpath.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_xpath = "  xpath => ${arr_xpath}\n"
   }
 

--- a/manifests/filter/zeromq.pp
+++ b/manifests/filter/zeromq.pp
@@ -189,14 +189,14 @@ define logstash::filter::zeromq (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 
   if ($sockopt != '') {
     validate_hash($sockopt)
     $var_sockopt = $sockopt
-    $arr_sockopt = inline_template('<%= "["+var_sockopt.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_sockopt = inline_template('<%= "["+@var_sockopt.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_sockopt = "  sockopt => ${arr_sockopt}\n"
   }
 

--- a/manifests/input/amqp.pp
+++ b/manifests/input/amqp.pp
@@ -311,7 +311,7 @@ define logstash::input::amqp (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/drupal_dblog.pp
+++ b/manifests/input/drupal_dblog.pp
@@ -207,14 +207,14 @@ define logstash::input::drupal_dblog (
   if ($databases != '') {
     validate_hash($databases)
     $var_databases = $databases
-    $arr_databases = inline_template('<%= "["+var_databases.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_databases = inline_template('<%= "["+@var_databases.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_databases = "  databases => ${arr_databases}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/elasticsearch.pp
+++ b/manifests/input/elasticsearch.pp
@@ -196,7 +196,7 @@ define logstash::input::elasticsearch (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/eventlog.pp
+++ b/manifests/input/eventlog.pp
@@ -172,7 +172,7 @@ define logstash::input::eventlog (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/exec.pp
+++ b/manifests/input/exec.pp
@@ -180,7 +180,7 @@ define logstash::input::exec (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/file.pp
+++ b/manifests/input/file.pp
@@ -240,7 +240,7 @@ define logstash::input::file (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/ganglia.pp
+++ b/manifests/input/ganglia.pp
@@ -178,7 +178,7 @@ define logstash::input::ganglia (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/gelf.pp
+++ b/manifests/input/gelf.pp
@@ -198,7 +198,7 @@ define logstash::input::gelf (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/gemfire.pp
+++ b/manifests/input/gemfire.pp
@@ -228,7 +228,7 @@ define logstash::input::gemfire (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/generator.pp
+++ b/manifests/input/generator.pp
@@ -207,7 +207,7 @@ define logstash::input::generator (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/graphite.pp
+++ b/manifests/input/graphite.pp
@@ -232,7 +232,7 @@ define logstash::input::graphite (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/heroku.pp
+++ b/manifests/input/heroku.pp
@@ -176,7 +176,7 @@ define logstash::input::heroku (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/imap.pp
+++ b/manifests/input/imap.pp
@@ -222,7 +222,7 @@ define logstash::input::imap (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/irc.pp
+++ b/manifests/input/irc.pp
@@ -231,7 +231,7 @@ define logstash::input::irc (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/log4j.pp
+++ b/manifests/input/log4j.pp
@@ -199,7 +199,7 @@ define logstash::input::log4j (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/lumberjack.pp
+++ b/manifests/input/lumberjack.pp
@@ -200,7 +200,7 @@ define logstash::input::lumberjack (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/lumberjack2.pp
+++ b/manifests/input/lumberjack2.pp
@@ -202,7 +202,7 @@ define logstash::input::lumberjack2 (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/pipe.pp
+++ b/manifests/input/pipe.pp
@@ -173,7 +173,7 @@ define logstash::input::pipe (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/rabbitmq.pp
+++ b/manifests/input/rabbitmq.pp
@@ -346,7 +346,7 @@ define logstash::input::rabbitmq (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/redis.pp
+++ b/manifests/input/redis.pp
@@ -234,7 +234,7 @@ define logstash::input::redis (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/relp.pp
+++ b/manifests/input/relp.pp
@@ -182,7 +182,7 @@ define logstash::input::relp (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/snmptrap.pp
+++ b/manifests/input/snmptrap.pp
@@ -192,7 +192,7 @@ define logstash::input::snmptrap (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/sqs.pp
+++ b/manifests/input/sqs.pp
@@ -238,7 +238,7 @@ define logstash::input::sqs (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/stdin.pp
+++ b/manifests/input/stdin.pp
@@ -165,7 +165,7 @@ define logstash::input::stdin (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/stomp.pp
+++ b/manifests/input/stomp.pp
@@ -197,7 +197,7 @@ define logstash::input::stomp (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/syslog.pp
+++ b/manifests/input/syslog.pp
@@ -224,7 +224,7 @@ define logstash::input::syslog (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/tcp.pp
+++ b/manifests/input/tcp.pp
@@ -253,7 +253,7 @@ define logstash::input::tcp (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/twitter.pp
+++ b/manifests/input/twitter.pp
@@ -218,7 +218,7 @@ define logstash::input::twitter (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/udp.pp
+++ b/manifests/input/udp.pp
@@ -185,7 +185,7 @@ define logstash::input::udp (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/varnishlog.pp
+++ b/manifests/input/varnishlog.pp
@@ -171,7 +171,7 @@ define logstash::input::varnishlog (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/websocket.pp
+++ b/manifests/input/websocket.pp
@@ -181,7 +181,7 @@ define logstash::input::websocket (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/xmpp.pp
+++ b/manifests/input/xmpp.pp
@@ -204,7 +204,7 @@ define logstash::input::xmpp (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/zenoss.pp
+++ b/manifests/input/zenoss.pp
@@ -320,7 +320,7 @@ define logstash::input::zenoss (
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/input/zeromq.pp
+++ b/manifests/input/zeromq.pp
@@ -236,14 +236,14 @@ define logstash::input::zeromq (
   if ($sockopt != '') {
     validate_hash($sockopt)
     $var_sockopt = $sockopt
-    $arr_sockopt = inline_template('<%= "["+var_sockopt.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_sockopt = inline_template('<%= "["+@var_sockopt.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_sockopt = "  sockopt => ${arr_sockopt}\n"
   }
 
   if ($add_field != '') {
     validate_hash($add_field)
     $var_add_field = $add_field
-    $arr_add_field = inline_template('<%= "["+var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_add_field = inline_template('<%= "["+@var_add_field.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_add_field = "  add_field => ${arr_add_field}\n"
   }
 

--- a/manifests/output/circonus.pp
+++ b/manifests/output/circonus.pp
@@ -134,7 +134,7 @@ define logstash::output::circonus (
   if ($annotation != '') {
     validate_hash($annotation)
     $var_annotation = $annotation
-    $arr_annotation = inline_template('<%= "["+var_annotation.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_annotation = inline_template('<%= "["+@var_annotation.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_annotation = "  annotation => ${arr_annotation}\n"
   }
 

--- a/manifests/output/cloudwatch.pp
+++ b/manifests/output/cloudwatch.pp
@@ -305,7 +305,7 @@ define logstash::output::cloudwatch (
   if ($dimensions != '') {
     validate_hash($dimensions)
     $var_dimensions = $dimensions
-    $arr_dimensions = inline_template('<%= "["+var_dimensions.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_dimensions = inline_template('<%= "["+@var_dimensions.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_dimensions = "  dimensions => ${arr_dimensions}\n"
   }
 

--- a/manifests/output/email.pp
+++ b/manifests/output/email.pp
@@ -222,14 +222,14 @@ define logstash::output::email (
   if ($match != '') {
     validate_hash($match)
     $var_match = $match
-    $arr_match = inline_template('<%= "["+var_match.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_match = inline_template('<%= "["+@var_match.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_match = "  match => ${arr_match}\n"
   }
 
   if ($options != '') {
     validate_hash($options)
     $var_options = $options
-    $arr_options = inline_template('<%= "["+var_options.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_options = inline_template('<%= "["+@var_options.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_options = "  options => ${arr_options}\n"
   }
 

--- a/manifests/output/gelf.pp
+++ b/manifests/output/gelf.pp
@@ -252,7 +252,7 @@ define logstash::output::gelf (
   if ($custom_fields != '') {
     validate_hash($custom_fields)
     $var_custom_fields = $custom_fields
-    $arr_custom_fields = inline_template('<%= "["+var_custom_fields.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_custom_fields = inline_template('<%= "["+@var_custom_fields.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_custom_fields = "  custom_fields => ${arr_custom_fields}\n"
   }
 

--- a/manifests/output/graphite.pp
+++ b/manifests/output/graphite.pp
@@ -218,7 +218,7 @@ define logstash::output::graphite (
   if ($metrics != '') {
     validate_hash($metrics)
     $var_metrics = $metrics
-    $arr_metrics = inline_template('<%= "["+var_metrics.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_metrics = inline_template('<%= "["+@var_metrics.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_metrics = "  metrics => ${arr_metrics}\n"
   }
 

--- a/manifests/output/graphtastic.pp
+++ b/manifests/output/graphtastic.pp
@@ -187,7 +187,7 @@ define logstash::output::graphtastic (
   if ($metrics != '') {
     validate_hash($metrics)
     $var_metrics = $metrics
-    $arr_metrics = inline_template('<%= "["+var_metrics.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_metrics = inline_template('<%= "["+@var_metrics.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_metrics = "  metrics => ${arr_metrics}\n"
   }
 

--- a/manifests/output/http.pp
+++ b/manifests/output/http.pp
@@ -176,14 +176,14 @@ define logstash::output::http (
   if ($headers != '') {
     validate_hash($headers)
     $var_headers = $headers
-    $arr_headers = inline_template('<%= "["+var_headers.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_headers = inline_template('<%= "["+@var_headers.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_headers = "  headers => ${arr_headers}\n"
   }
 
   if ($mapping != '') {
     validate_hash($mapping)
     $var_mapping = $mapping
-    $arr_mapping = inline_template('<%= "["+var_mapping.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_mapping = inline_template('<%= "["+@var_mapping.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_mapping = "  mapping => ${arr_mapping}\n"
   }
 

--- a/manifests/output/librato.pp
+++ b/manifests/output/librato.pp
@@ -171,21 +171,21 @@ define logstash::output::librato (
   if ($counter != '') {
     validate_hash($counter)
     $var_counter = $counter
-    $arr_counter = inline_template('<%= "["+var_counter.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_counter = inline_template('<%= "["+@var_counter.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_counter = "  counter => ${arr_counter}\n"
   }
 
   if ($annotation != '') {
     validate_hash($annotation)
     $var_annotation = $annotation
-    $arr_annotation = inline_template('<%= "["+var_annotation.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_annotation = inline_template('<%= "["+@var_annotation.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_annotation = "  annotation => ${arr_annotation}\n"
   }
 
   if ($gauge != '') {
     validate_hash($gauge)
     $var_gauge = $gauge
-    $arr_gauge = inline_template('<%= "["+var_gauge.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_gauge = inline_template('<%= "["+@var_gauge.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_gauge = "  gauge => ${arr_gauge}\n"
   }
 

--- a/manifests/output/metriccatcher.pp
+++ b/manifests/output/metriccatcher.pp
@@ -194,42 +194,42 @@ define logstash::output::metriccatcher (
   if ($meter != '') {
     validate_hash($meter)
     $var_meter = $meter
-    $arr_meter = inline_template('<%= "["+var_meter.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_meter = inline_template('<%= "["+@var_meter.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_meter = "  meter => ${arr_meter}\n"
   }
 
   if ($biased != '') {
     validate_hash($biased)
     $var_biased = $biased
-    $arr_biased = inline_template('<%= "["+var_biased.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_biased = inline_template('<%= "["+@var_biased.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_biased = "  biased => ${arr_biased}\n"
   }
 
   if ($gauge != '') {
     validate_hash($gauge)
     $var_gauge = $gauge
-    $arr_gauge = inline_template('<%= "["+var_gauge.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_gauge = inline_template('<%= "["+@var_gauge.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_gauge = "  gauge => ${arr_gauge}\n"
   }
 
   if ($uniform != '') {
     validate_hash($uniform)
     $var_uniform = $uniform
-    $arr_uniform = inline_template('<%= "["+var_uniform.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_uniform = inline_template('<%= "["+@var_uniform.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_uniform = "  uniform => ${arr_uniform}\n"
   }
 
   if ($counter != '') {
     validate_hash($counter)
     $var_counter = $counter
-    $arr_counter = inline_template('<%= "["+var_counter.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_counter = inline_template('<%= "["+@var_counter.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_counter = "  counter => ${arr_counter}\n"
   }
 
   if ($timer != '') {
     validate_hash($timer)
     $var_timer = $timer
-    $arr_timer = inline_template('<%= "["+var_timer.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_timer = inline_template('<%= "["+@var_timer.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_timer = "  timer => ${arr_timer}\n"
   }
 

--- a/manifests/output/pagerduty.pp
+++ b/manifests/output/pagerduty.pp
@@ -151,7 +151,7 @@ define logstash::output::pagerduty (
   if ($details != '') {
     validate_hash($details)
     $var_details = $details
-    $arr_details = inline_template('<%= "["+var_details.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_details = inline_template('<%= "["+@var_details.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_details = "  details => ${arr_details}\n"
   }
 

--- a/manifests/output/riak.pp
+++ b/manifests/output/riak.pp
@@ -208,21 +208,21 @@ define logstash::output::riak (
   if ($nodes != '') {
     validate_hash($nodes)
     $var_nodes = $nodes
-    $arr_nodes = inline_template('<%= "["+var_nodes.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_nodes = inline_template('<%= "["+@var_nodes.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_nodes = "  nodes => ${arr_nodes}\n"
   }
 
   if ($bucket_props != '') {
     validate_hash($bucket_props)
     $var_bucket_props = $bucket_props
-    $arr_bucket_props = inline_template('<%= "["+var_bucket_props.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_bucket_props = inline_template('<%= "["+@var_bucket_props.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_bucket_props = "  bucket_props => ${arr_bucket_props}\n"
   }
 
   if ($ssl_opts != '') {
     validate_hash($ssl_opts)
     $var_ssl_opts = $ssl_opts
-    $arr_ssl_opts = inline_template('<%= "["+var_ssl_opts.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_ssl_opts = inline_template('<%= "["+@var_ssl_opts.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_ssl_opts = "  ssl_opts => ${arr_ssl_opts}\n"
   }
 

--- a/manifests/output/riemann.pp
+++ b/manifests/output/riemann.pp
@@ -167,7 +167,7 @@ define logstash::output::riemann (
   if ($riemann_event != '') {
     validate_hash($riemann_event)
     $var_riemann_event = $riemann_event
-    $arr_riemann_event = inline_template('<%= "["+var_riemann_event.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_riemann_event = inline_template('<%= "["+@var_riemann_event.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_riemann_event = "  riemann_event => ${arr_riemann_event}\n"
   }
 

--- a/manifests/output/statsd.pp
+++ b/manifests/output/statsd.pp
@@ -204,14 +204,14 @@ define logstash::output::statsd (
   if ($timing != '') {
     validate_hash($timing)
     $var_timing = $timing
-    $arr_timing = inline_template('<%= "["+var_timing.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_timing = inline_template('<%= "["+@var_timing.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_timing = "  timing => ${arr_timing}\n"
   }
 
   if ($count != '') {
     validate_hash($count)
     $var_count = $count
-    $arr_count = inline_template('<%= "["+var_count.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_count = inline_template('<%= "["+@var_count.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_count = "  count => ${arr_count}\n"
   }
 

--- a/manifests/output/zeromq.pp
+++ b/manifests/output/zeromq.pp
@@ -164,7 +164,7 @@ define logstash::output::zeromq (
   if ($sockopt != '') {
     validate_hash($sockopt)
     $var_sockopt = $sockopt
-    $arr_sockopt = inline_template('<%= "["+var_sockopt.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
+    $arr_sockopt = inline_template('<%= "["+@var_sockopt.sort.collect { |k,v| "\"#{k}\", \"#{v}\"" }.join(", ")+"]" %>')
     $opt_sockopt = "  sockopt => ${arr_sockopt}\n"
   }
 


### PR DESCRIPTION
Puppet 3.2 adds a deprecation warning about using e.g. '<%= variable %>' in templates, advising us to switch to '<%= @variable %>' (as the former will be removed someday).

This patch switches several (107) instances of inline templates using '<%= [var_x.sort.collect..' to '<%= [@var_x.sort.collect..' so they no longer trigger the warning.

perl -pi -e 's{(?<=\Q"["+\E)(?=var)}{@}g' manifests/_.pp manifests/_/*.pp

cc @phrawzty
