### PR TITLE
define logstash::configdir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,8 @@ class logstash(
   $initfiles      = undef,
   $defaultsfiles  = undef,
   $logstash_user  = $logstash::params::logstash_user,
-  $logstash_group = $logstash::params::logstash_group
+  $logstash_group = $logstash::params::logstash_group,
+  $configdir      = $logstash::params::configdir,
 ) inherits logstash::params {
 
   anchor {'logstash::begin': }


### PR DESCRIPTION
${logstash::configdir} is used throughout the modules but isn't actually defined.  It is pulling it in from the inherited params, but that appears to be more of a scoping oversight rather than correct functionality.
