### PR TITLE
Permit HTTP(s) for downloading logstash

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -104,6 +104,7 @@ class logstash::package {
             require => Exec['create_install_dir'],
             backup  => false,
           }
+          File["${logstash::installpath}/${basefilename}"] -> File["${logstash::installpath}/logstash.jar"]
         }
         ftp, https, http: {
           exec { 'download-logstash':
@@ -112,6 +113,7 @@ class logstash::package {
             creates => "${logstash::installpath}/${basefilename}",
             require => Exec['create_install_dir'],
           }
+          Exec['download-logstash'] -> File["${logstash::installpath}/logstash.jar"]
         }
         default: { 
           fail("Protocol must be puppet, http, https, or ftp.")


### PR DESCRIPTION
This method preserves dependencies, while allowing protocols other than puppet to fetch logstash.

Perhaps this is the time to examine whether or not add providers beyond package and custom would be appropriate?  Something like uri perhaps?
