### PR TITLE
remove installpath when ensure => absent

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -134,7 +134,14 @@ class logstash::package {
       }
 
     } else {
-      ## Do we need to do anything when removing ?
+
+      # If not present, remove installpath, leave logfiles
+      file { $logstash::installpath:
+        ensure  => 'absent',
+        force   => true,
+        recurse => true,
+        purge   => true,
+      }
     }
 
   }


### PR DESCRIPTION
This is the only other thing I found for package that wasn't being handled by ensure => absent.  I personally like log files to be left when removing a package as they represent a time in history the package did exist.  I can update to remove logdir too if needed.
