### PR TITLE
set logstash logdir perms when using custom jar provider

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -89,6 +89,13 @@ class logstash::package {
         creates => $logstash::params::logdir;
       }
 
+      file { $logstash::params::logdir:
+        ensure  => 'directory',
+        owner   => $logstash::logstash_user,
+        group   => $logstash::logstash_group,
+        require => Exec['create_log_dir'],
+      }
+
       # Place the jar file
       $filenameArray = split($logstash::jarfile, '/')
       $basefilename = $filenameArray[-1]


### PR DESCRIPTION
I added this only to the custom package provider since a package itself should manage the permissions on the logdir it creates.
