### PR TITLE
Allow configuration of number of open files

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,7 @@ class logstash(
   $logstash_group = $logstash::params::logstash_group,
   $configdir      = $logstash::params::configdir,
   $conffile       = undef,
+  $open_files     = $logstash::params::open_files,
 ) inherits logstash::params {
 
   anchor {'logstash::begin': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,6 +54,9 @@ class logstash::params {
   $logstash_user  = 'root'
   $logstash_group = 'root'
 
+  # Number of open files set in init script
+  $open_files = 2048
+
   #### Internal module values
 
   # packages

--- a/templates/etc/init.d/logstash.init.Debian.erb
+++ b/templates/etc/init.d/logstash.init.Debian.erb
@@ -63,7 +63,7 @@ CONF_DIR=<%= @configdir %>
 LOG_FILE=$LOG_DIR/$NAME.log
 
 # Open File limit
-OPEN_FILES=2048
+OPEN_FILES=<%= scope.lookupvar('logstash::open_files') %>
 
 # Nice level
 NICE=19

--- a/templates/etc/init.d/logstash.init.RedHat.erb
+++ b/templates/etc/init.d/logstash.init.RedHat.erb
@@ -59,7 +59,7 @@ CONF_DIR=<%= @configdir %>
 LOG_FILE=$LOG_DIR/$NAME.log
 
 # Open File limit
-OPEN_FILES=2048
+OPEN_FILES=<%= scope.lookupvar('logstash::open_files') %>
 
 # Nice level
 NICE=19


### PR DESCRIPTION
The default of 2048 is not sufficient for all configurations
and is currently hardcoded into the init script
