### PR TITLE
Honour the NICE setting

### DIFF
--- a/templates/etc/init.d/logstash.init.Debian.erb
+++ b/templates/etc/init.d/logstash.init.Debian.erb
@@ -117,6 +117,7 @@ case "$1" in
          # Start Daemon
          start-stop-daemon --start -b --user "$LS_USER" -c "$LS_USER":"$LS_GROUP" \
            -d "$LS_HOME" --pidfile "$PID_FILE" --make-pidfile \
+           -N $NICE \
            --exec "$JAVA" -- $LS_JAVA_OPTS -jar $DAEMON $DAEMON_OPTS
 
          sleep 1


### PR DESCRIPTION
Either set in /etc/init.d/logstash-agent, or in
/etc/default/logstash-agent.

See http://man.he.net/man8/start-stop-daemon
