### PR TITLE
grep ps output instead of pgrep

### DIFF
--- a/templates/etc/init.d/logstash.init.RedHat.erb
+++ b/templates/etc/init.d/logstash.init.RedHat.erb
@@ -126,7 +126,7 @@ do_start()
   RETVAL=$?
   # sleeping otherwise there is not enough time to show up
   sleep 2
-  local PID=`pgrep -f "${JAVA} ${ARGS}"`
+  local PID=$(ps e | grep "${JAVA} ${ARGS}" | grep -v grep | awk '{print $1}')
   echo $PID > $PID_FILE
   success
 }


### PR DESCRIPTION
For some reason, pgrep fails to match the PID and write it to file. In my environment, the following command

``` bash
pgrep -f "/usr/bin/java -Xmx256m -Djava.io.tmpdir=/usr/share/logstash/tmp -Xmx384m -XX:+UseConcMarkSweepGC -jar /usr/share/logstash/logstash.jar agent --config /etc/logstash/indexer/config --log /var/log/logstash/logstash-indexer.log -w 4"
```

returns nothing, whereas

``` bash
ps e | grep "/usr/bin/java -Xmx256m -Djava.io.tmpdir=/usr/share/logstash/tmp -Xmx384m -XX:+UseConcMarkSweepGC -jar /usr/share/logstash/logstash.jar agent --config /etc/logstash/indexer/config --log /var/log/logstash/logstash-indexer.log -w 4" | grep -v grep | awk '{print $1}'
```

reliably locates the PID.

(accidentally closed prior pull request, doesn't seem to be a way to reopen, whoops)
