### PR TITLE
add $PATH to the end of the PATH in the init scripts 

### DIFF
--- a/templates/etc/init.d/logstash.init.Debian.erb
+++ b/templates/etc/init.d/logstash.init.Debian.erb
@@ -23,7 +23,7 @@ end
 
 set -e
 
-PATH=/bin:/usr/bin:/sbin:/usr/sbin
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
 NAME=<%=@proc_name%>
 DESC="Logstash Daemon <%=@desc_name%>"
 DEFAULT=/etc/default/$NAME

--- a/templates/etc/init.d/logstash.init.RedHat.erb
+++ b/templates/etc/init.d/logstash.init.RedHat.erb
@@ -29,7 +29,7 @@ end
 
 . /etc/rc.d/init.d/functions
 
-PATH=/bin:/usr/bin:/sbin:/usr/sbin
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PATH
 NAME=<%=@proc_name%>
 DESC="Logstash Daemon <%=@desc_name%>"
 DEFAULT=/etc/sysconfig/$NAME


### PR DESCRIPTION
Since the PATH can not be overridden, add $PATH to the end to ensure custom java installs with set paths will still work.
