### PR TITLE
support defaults file when provider == package

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -100,7 +100,7 @@ class logstash::service {
 
     } else {
 
-      if $logstash::provider == 'custom' {
+      if $logstash::provider == 'custom' or $logstash::provider == 'package' {
 
         file { "${logstash::params::defaults_location}/logstash":
           ensure => present,


### PR DESCRIPTION
Support setting the defaults file to enable logstash when using the provider package.  This is to support the official packages now provided by logstash.

I was going to add support for enabling/disabling the official apt and yum repos, but I know you're in the middle of a rewrite for this module so I just did this small change.  If you'd like that support now though I'm happy to add it.
