### PR TITLE
Fix markdown code sample layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,13 @@ If you want a specific java package/version:
      }
 
 If you want to define your own logstash config (multi-instance):
+
      class { 'logstash':
        conffile => { 'agent' => 'puppet:///data/logstash/agent.config' }
      }
 
 If you want to define your own logstash config (single-instance):
+
      class { 'logstash':
        conffile => 'puppet:///data/logstash/agent.config'
      }


### PR DESCRIPTION
Without the extra linebreak the code isn't formatted by markdown as pre-formatted text
