### PR TITLE
Adds name to centos repo

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -42,6 +42,7 @@ class logstash::repo {
     }
     'RedHat': {
       yumrepo { 'logstash':
+        descr    => 'Logstash Centos Repo',
         baseurl  => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/centos",
         gpgcheck => 1,
         gpgkey   => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',


### PR DESCRIPTION
Without the descr, yum will throw a harmless error every time you try and install software

```
Repository 'logstash' is missing name in configuration, using id
```

Note: It seems counter intuitive, but puppet yumrepo uses 'descr' to set the 'name', where as 'name' does nothing. 
https://groups.google.com/forum/#!topic/puppet-users/QEM0XquEyLY

Also, I swear I submitted this pull request an hour ago, but I can't find it, so I'm submitting it again.
