### PR TITLE
Fix typo in group name variable

### DIFF
--- a/manifests/patternfile.pp
+++ b/manifests/patternfile.pp
@@ -55,7 +55,7 @@ define logstash::patternfile (
   file { "${patterns_dir}/${filename_real}":
     ensure  => 'file',
     owner   => $logstash::logstash_user,
-    group   => $logstash::logstsah_group,
+    group   => $logstash::logstash_group,
     mode    => '0440',
     source  => $source,
   }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -88,7 +88,7 @@ define logstash::plugin (
   file { "${plugins_dir}/logstash/${type}s/${filename_real}":
     ensure  => $ensure,
     owner   => $logstash::logstash_user,
-    group   => $logstash::logstsah_group,
+    group   => $logstash::logstash_group,
     mode    => '0440',
     source  => $source,
   }


### PR DESCRIPTION
Fix typo of `logstsah_group` instead of `logstash_group`
