### PR TITLE
Change logstash user to logstash under debian/ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,8 +56,16 @@ class logstash::params {
   # User and Group for the files and user to run the service as.
   case $::kernel {
     'Linux': {
-      $logstash_user  = 'root'
-      $logstash_group = 'root'
+       case $operatingsystem {
+        /^(Debian|Ubuntu)$/: {
+          $logstash_user  = 'logstash'
+          $logstash_group = 'logstash'
+        }
+        default: {
+          $logstash_user  = 'root'
+          $logstash_group = 'root'
+        }
+      }
     }
     'Darwin': {
       $logstash_user  = 'root'


### PR DESCRIPTION
In Debian and Ubuntu the logstash user and group should be logstash, as the programm runs as that user. Without my change the files will belong to root. 
I found out about this when logstash refused to start because it could not read the pattern file I gave it. It belonged to root with no read permissions for the process.

Thank you!
