### PR TITLE
Add support for passing in logstash-contrib package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ via contrib_package_url:
        contrib_package_url => 'http://download.elasticsearch.org/logstash/logstash/packages/centos/logstash-contrib-1.4.0-1_centos.noarch.rpm'
      }
 
+with a version specified:
+
+     class { 'logstash':
+       install_contrib => true,
+       contrib_version => '1.4.0'
+     }
+
+
+
 ## Configuration Overview
 
 The Logstash configuration can be supplied as a single static file or dynamically built from multiple smaller files.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,11 @@
 #   case).
 #
 # [*version*]
-#   String to set the specific version you want to install.
+#   String to set the specific core package version you want to install.
+#   Defaults to <tt>false</tt>.
+#
+# [*contrib_version*]
+#   String to set the specific contrib package version you want to install.
 #   Defaults to <tt>false</tt>.
 #
 # [*restart_on_change*]
@@ -156,6 +160,7 @@ class logstash(
   $restart_on_change   = $logstash::params::restart_on_change,
   $autoupgrade         = $logstash::params::autoupgrade,
   $version             = false,
+  $contrib_version     = false,
   $software_provider   = 'package',
   $package_url         = undef,
   $contrib_package_url = undef,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -73,14 +73,16 @@ class logstash::package {
 
   #class { 'logstash::package::core': }
   logstash::package::install { 'logstash':
-    package_url => $logstash::package_url
+    package_url => $logstash::package_url,
+    version     => $logstash::version
   }
 
   if ($logstash::install_contrib == true) {
 
     #class { 'logstash::package::contrib': }
     logstash::package::install { 'logstash-contrib':
-      package_url => $logstash::contrib_package_url
+      package_url => $logstash::contrib_package_url,
+      version     => $logstash::contrib_version
     }
 
     # Ensure we install Core package before contrib

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -11,6 +11,9 @@
 #   This can be a http,https or ftp resource for remote packages
 #   puppet:// resource or file:/ for local packages
 #
+# [*version*]
+#   Version of package to install
+#
 # === Examples
 #
 # This class may be imported by other classes to use its functionality:
@@ -25,7 +28,8 @@
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
 define logstash::package::install(
-  $package_url = undef
+  $package_url = undef,
+  $version = undef
 ) {
 
   Exec {
@@ -41,7 +45,7 @@ define logstash::package::install(
   if $logstash::ensure == 'present' {
 
     # Check if we want to install a specific version or not
-    if $logstash::version == false {
+    if $version == false {
 
       $package_ensure = $logstash::autoupgrade ? {
         true  => 'latest',
@@ -51,7 +55,7 @@ define logstash::package::install(
     } else {
 
       # install specific version
-      $package_ensure = $logstash::version
+      $package_ensure = $version
 
     }
 

--- a/spec/classes/001_logstash_init_debian_spec.rb
+++ b/spec/classes/001_logstash_init_debian_spec.rb
@@ -168,7 +168,7 @@ describe 'logstash', :type => 'class' do
 
             let :params do {
               :install_contrib => true,
-              :version => '1.0'
+              :contrib_version => '1.0'
             } end
 
             it { should contain_class('logstash::package') }

--- a/spec/classes/002_logstash_init_redhat_spec.rb
+++ b/spec/classes/002_logstash_init_redhat_spec.rb
@@ -165,7 +165,7 @@ describe 'logstash', :type => 'class' do
 
             let :params do {
               :install_contrib => true,
-              :version => '1.0'
+              :contrib_version => '1.0'
             } end
 
             it { should contain_class('logstash::package') }


### PR DESCRIPTION
On Debian/Ubuntu, the versions for `logstash` and `logstash-contrib` packages differ.  This adds an additional parameter to pass in a separate version for the `logstash-contrib` package.  This should resolve #167

Tests pass locally for me and I've signed the CLA already.
