### PR TITLE
ensure the upstart script is deleted when using init

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -32,6 +32,11 @@ class logstash::service {
 
     init: {
       logstash::service::init { $logstash::params::service_name: }
+
+      # in case of init, make sure the upstart script provided by the package doesn't interfere:
+      file { "/etc/init/logstash.conf":
+        ensure  => 'absent',
+      }
     }
 
     default: {


### PR DESCRIPTION
ensure upstart script (from the package) is deleted, when using init.
