### PR TITLE
enable running logstash under different user/group

### DIFF
--- a/templates/etc/init.d/logstash.Debian.erb
+++ b/templates/etc/init.d/logstash.Debian.erb
@@ -33,8 +33,8 @@ fi
 # The following variables can be overwritten in $DEFAULT
 
 # Run logstash as this user ID and group ID
-LS_USER=logstash
-LS_GROUP=logstash
+LS_USER=<%= @logstash_user %>
+LS_GROUP=<%= @logstash_group %>
 
 JAVA=/usr/bin/java
 


### PR DESCRIPTION
when specififying logstash_user / logstash_group these parameters are
not automatically transfered to the init.d scripts. One would
additionally have to supply init_defaults. This seems
counter-interuitive. With this (wip) patch, we now allow running
logstash as different user/group on Debian/Ubuntu.