### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,17 @@ By default the resulting filename of the pattern will match that of the source. 
        source   => 'puppet:///path/to/extra_patterns_firewall_v1',
        filename => 'extra_patterns_firewall'
      }
+     
+**IMPORTANT NOTE**: Using logstash::patternfile places new patterns in the correct directory, however, it does NOT cause the path to be included automatically for filters (example: grok filter). You will still need to include this path (by default, /etc/logstash/patterns/) explicitly in your configurations.
+
+Example: If using 'grok' in one of your configurations, you must include the pattern path in each filter like this:
+
+```
+grok {
+      patterns_dir => "/etc/logstash/patterns/"
+      ...
+    }
+```
 
 ## Plugins
 


### PR DESCRIPTION
update documentation to include newbie instructions that using custom pattern_dirs with puppet doesn't automatically pull them into grok filters

hopefully this will save fellow logstash newbies several hours of frustrating debugging like I just went through :)
