### PR TITLE
For patterns and plugins using file:// in source should be supported

### DIFF
--- a/manifests/patternfile.pp
+++ b/manifests/patternfile.pp
@@ -43,7 +43,7 @@ define logstash::patternfile (
   $filename = '',
 ){
 
-  validate_re($source, '^puppet://', 'Source must be from a puppet fileserver (begin with puppet://)' )
+  validate_re($source, '^(puppet|file)://', 'Source must be either from a puppet fileserver or a locally accessible file (begins with either puppet:// or file://)' )
 
   $patterns_dir = "${logstash::configdir}/patterns"
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -68,7 +68,7 @@ define logstash::plugin (
   $filename = '',
 ){
 
-  validate_re($source, '^puppet://', 'Source must be from a puppet fileserver (begin with puppet://)' )
+  validate_re($source, '^(puppet|file)://', 'Source must be either from a puppet fileserver or a locally accessible file (begins with either puppet:// or file://)' )
 
   if ! ($ensure in [ 'present', 'absent' ]) {
     fail("\"${ensure}\" is not a valid ensure parameter value")

--- a/spec/defines/001_logstash_patternfile_spec.rb
+++ b/spec/defines/001_logstash_patternfile_spec.rb
@@ -22,6 +22,17 @@ describe 'logstash::patternfile', :type => 'define' do
 
   end
 
+  context 'using file:// schema' do
+
+    let(:params) { {
+      :source   => 'file:///mypatterns',
+    } }
+
+    it { should contain_logstash__patternfile('foopatterns') }
+    it { should contain_file('/etc/logstash/patterns/mypatterns').with( :source => 'file:///mypatterns') }
+
+  end
+
   context 'set filename' do
 
     let(:params) { {

--- a/spec/defines/002_logstash_plugin_spec.rb
+++ b/spec/defines/002_logstash_plugin_spec.rb
@@ -28,6 +28,19 @@ describe 'logstash::plugin', :type => 'define' do
 
       end
 
+      context 'using file:// schema' do
+
+        let(:params) { {
+          :ensure   => 'present',
+          :source   => 'file:///path/to/plugin.rb',
+          :type     => plugin_type 
+        } }
+
+        it { should contain_logstash__plugin('fooplugin') }
+        it { should contain_file("/etc/logstash/plugins/logstash/#{plugin_type}s/plugin.rb").with( :source => 'file:///path/to/plugin.rb') }
+
+      end
+
       context 'set filename' do
 
         let(:params) { {


### PR DESCRIPTION
There are cases when `puppet apply` is run not relying on puppet master thus not possible to utilize fileserver. In such cases using file:// in source for pattern files and plugins should be supported.