### PR TITLE
Provide full-length fingerprint for Apt key

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,7 +41,7 @@ class logstash::repo {
         location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => 'D88E42B4',
+        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
         key_server  => 'pgp.mit.edu',
         include_src => false,
       }


### PR DESCRIPTION
This actually enhances key security – and avoids a corresponding warning triggered by puppetlabs-apt >= 1.8.0.

See puppetlabs/puppetlabs-apt@f588f2651a68c5863aac7dac910d96bbc7531ef9 for the change in puppetlabs-apt and elastic/puppet-elasticsearch#294 for the corresponding change in puppet-elasticsearch.