### PR TITLE
Fix Travis-CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Puppet module for managing and configuring [Logstash](http://logstash.net/).
 
-[![Build Status](https://travis-ci.org/elasticsearch/puppet-logstash.png?branch=master)](https://travis-ci.org/elasticsearch/puppet-logstash)
+[![Build Status](https://travis-ci.org/elastic/puppet-logstash.png?branch=master)](https://travis-ci.org/elastic/puppet-logstash)
 
 ## Versions
 


### PR DESCRIPTION
The URL to Travis still references the old `elasticsearch` name which is no longer valid. This changes it to the new `elastic` instead.