### PR TITLE
Update Debian based install for 2.0.0 apt module

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -42,7 +42,7 @@ class logstash::repo {
         release     => 'stable',
         repos       => 'main',
         key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-        key_server  => 'pgp.mit.edu',
+        server      => 'pgp.mit.edu',
         include_src => false,
       }
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,8 +41,7 @@ class logstash::repo {
         location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-        server      => 'pgp.mit.edu',
+        key         => {'id' => '46095ACC8548582C1A2699A9D27D666CD88E42B4','server' => 'pgp.mit.edu'},
         include_src => false,
       }
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -42,7 +42,6 @@ class logstash::repo {
         release     => 'stable',
         repos       => 'main',
         key         => {'id' => '46095ACC8548582C1A2699A9D27D666CD88E42B4','server' => 'pgp.mit.edu'},
-        include_src => false,
       }
     }
     'RedHat': {


### PR DESCRIPTION
include_src was removed and now defaults to false
key_server renamed to server as a parameter of key
key now requires the parameter id is using a hash