### PR TITLE
puppetlabs apt 2.0.x compatibility

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -43,7 +43,7 @@ class logstash::repo {
         repos       => 'main',
         key => {
           id         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-          source  => 'pgp.mit.edu',
+          source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
 		},
 		include => { 'src' => false },
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,9 +41,12 @@ class logstash::repo {
         location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-        key_server  => 'pgp.mit.edu',
-        include_src => false,
+        key => {
+          id         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+          source  => 'pgp.mit.edu',
+		},
+		include => { 'src' => false },
+
       }
     }
     'RedHat': {


### PR DESCRIPTION
Hello,
Here is my version for puppetlabs/apt 2.0.x compatibility. I have tested on : 
Mac OS X 10.10.3 , vagrant 1.7.2, virtualbox 4.3.26, ubuntu 14.04, puppet 3.7.5 and librarian-puppet 2.1.0

Best
Zoltan