### PR TITLE
Added support for puppetlabs-apt >= 2.0

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,9 +41,10 @@ class logstash::repo {
         location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-        key_server  => 'pgp.mit.edu',
-        include_src => false,
+        key         => {
+          id => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+          server  => 'pgp.mit.edu'
+        }
       }
     }
     'RedHat': {

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "ispavailability/file_concat",
       "version_requirement": ">= 0.1.0"
+    },
+    {
+      "name": "puppetlabs/apt", 
+      "version_requirement": ">= 2.0.0 <3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This is needed for puppetlabs-apt >= 2.0 support.