### PR TITLE
Ensure recurse and purge is maintained in conf.d directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,6 +49,8 @@ class logstash::config {
 
     file { "${logstash::configdir}/conf.d":
       ensure  => directory,
+      purge   => $logstash::purge_configdir,
+      recurse => $logstash::purge_configdir,
       require => File[$logstash::configdir]
     }
 


### PR DESCRIPTION
At present, file resource for conf.d does not have the purge and recurse flags on and so the settings from the parent directory do not seem to be propagated.
