### PR TITLE
Restart on custom patternfile change

### DIFF
--- a/manifests/patternfile.pp
+++ b/manifests/patternfile.pp
@@ -52,11 +52,17 @@ define logstash::patternfile (
     default => $filename
   }
 
+  $notify_service = $logstash::restart_on_change ? {
+    true  => Class['logstash::service'],
+    false => undef,
+  }
+
   file { "${patterns_dir}/${filename_real}":
     ensure => 'file',
     owner  => $logstash::logstash_user,
     group  => $logstash::logstash_group,
     mode   => '0644',
+    notify  => $notify_service,
     source => $source,
   }
 


### PR DESCRIPTION
Changing a patternfile doesn't currently cause an update. Normally this is fine because you will be making an associated config change when adding a new patternfile. However, if you change an existing patternfile and only that file, nothing triggers a restart. 

This change causes a restart. Hopefully this will save others the pain of attempting to debug a grok pattern when the new pattern isn't getting loaded. :)