### PR TITLE
Add support for apt 2.x

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -33,17 +33,21 @@ class logstash::repo {
 
   case $::osfamily {
     'Debian': {
-      if !defined(Class['apt']) {
-        class { 'apt': }
-      }
+      include ::apt
+
+      Class['apt::update'] -> Package<| |>
 
       apt::source { 'logstash':
-        location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
-        release     => 'stable',
-        repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-        key_server  => 'pgp.mit.edu',
-        include_src => false,
+        location => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
+        release  => 'stable',
+        repos    => 'main',
+        key      => {
+          id     => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
+          server => 'pgp.mit.edu',
+        },
+        include  => {
+          source => false,
+        },
       }
     }
     'RedHat': {


### PR DESCRIPTION
Use the new key/include structures, and remove the conditional inclusion of `apt` that can be replaced with a simple include.