### PR TITLE
Clean up apt block

### DIFF
--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -153,7 +153,8 @@ define logstash::package::install(
     package { $name:
       ensure   => $package_ensure,
       source   => $pkg_source,
-      provider => $pkg_provider
+      provider => $pkg_provider,
+      tag      => ['logstash-package'],
     }
 
   } else {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -33,9 +33,8 @@ class logstash::repo {
 
   case $::osfamily {
     'Debian': {
-      if !defined(Class['apt']) {
-        class { 'apt': }
-      }
+      include ::apt
+      Class['apt::update'] -> Package<| tag == 'logstash-package' |>
 
       apt::source { 'logstash':
         location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",


### PR DESCRIPTION
Remove the conditional block for including the apt class, and ensure that apt::update does its thing prior to installing packages (this is a [known limitation](https://github.com/puppetlabs/puppetlabs-apt#limitations)).