### PR TITLE
Removed GPG server and instead get the key file itself. 

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -41,8 +41,8 @@ class logstash::repo {
         location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
         release     => 'stable',
         repos       => 'main',
-        key         => '46095ACC8548582C1A2699A9D27D666CD88E42B4',
-        key_server  => 'pgp.mit.edu',
+        key         => 'D88E42B4',
+        key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
         include_src => false,
       }
     }


### PR DESCRIPTION
Please see Issue #191

I would like to ask why using 40 characters key was reverted in elasticsearch module? I can update both modules if it is useful, to avoid ap module warnings.