### PR TITLE
Add some minimal OpenBSD support:

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,10 @@
 # [*service_provider*]
 #   Service provider to use. By Default when a single service provider is possibe that one is selected.
 #
+# [*service_flags*]
+#   String, used to steer the OpenBSD service flags, in order to override/change the default values.
+#   defaults to undef
+#
 # [*init_defaults*]
 #   Defaults file content in hash representation
 #
@@ -174,6 +178,7 @@ class logstash(
   $java_install        = false,
   $java_package        = undef,
   $service_provider    = 'init',
+  $service_flags       = undef,
   $init_defaults       = undef,
   $init_defaults_file  = undef,
   $init_template       = undef,
@@ -235,7 +240,9 @@ class logstash(
   class { 'logstash::config': }
 
   # service(s)
-  class { 'logstash::service': }
+  class { 'logstash::service':
+    service_flags => $service_flags,
+  }
 
   if $java_install == true {
     # Install java

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,6 +67,10 @@ class logstash::params {
       $logstash_user  = 'root'
       $logstash_group = 'wheel'
     }
+    'OpenBSD': {
+      $logstash_user  = '_logstash'
+      $logstash_group = '_logstash'
+    }
     default: {
       fail("\"${module_name}\" provides no user/group default value
            for \"${::kernel}\"")
@@ -81,6 +85,9 @@ class logstash::params {
     }
     'Darwin': {
       $download_tool = 'curl -o'
+    }
+    'OpenBSD': {
+      $download_tool = 'ftp -o'
     }
     default: {
       fail("\"${module_name}\" provides no download tool default value
@@ -102,6 +109,12 @@ class logstash::params {
       $installpath = '/Library/Logstash'
       $plugin = '/Library/Logstash/bin/plugin'
     }
+    'OpenBSD': {
+      $configdir = '/etc/logstash'
+      $package_dir = undef
+      $installpath = undef
+      $plugin = '/usr/local/logstash/bin/plugin'
+    }
     default: {
       fail("\"${module_name}\" provides no config directory default value
            for \"${::kernel}\"")
@@ -119,6 +132,11 @@ class logstash::params {
       # main application
       $package = [ 'logstash' ]
       $contrib = [ 'logstash-contrib' ]
+    }
+    'OpenBSD': {
+      # main application
+      $package = [ 'logstash' ]
+      $contrib = undef
     }
     default: {
       fail("\"${module_name}\" provides no package default value
@@ -150,6 +168,14 @@ class logstash::params {
       $service_hasstatus  = true
       $service_pattern    = $service_name
       $service_providers  = [ 'launchd' ]
+      $defaults_location  = false
+    }
+    'OpenBSD': {
+      $service_name       = 'logstash'
+      $service_hasrestart = true
+      $service_hasstatus  = true
+      $service_pattern    = undef
+      $service_providers  = [ 'openbsd' ]
       $defaults_location  = false
     }
     default: {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -10,8 +10,8 @@
 #
 # === Parameters
 #
-# This class does not provide any parameters.
-#
+# ===== service_flags
+# String, used on OpenBSD to override/set the service flags, defaults to undef.
 #
 # === Examples
 #
@@ -26,12 +26,19 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-class logstash::service {
+class logstash::service (
+  $service_flags = undef,
+){
 
   case $logstash::service_provider {
 
-    init: {
+    'init': {
       logstash::service::init { $logstash::params::service_name: }
+    }
+    'openbsd': {
+      logstash::service::openbsd { $logstash::params::service_name:
+        service_flags => $service_flags,
+      }
     }
 
     default: {

--- a/manifests/service/openbsd.pp
+++ b/manifests/service/openbsd.pp
@@ -1,0 +1,107 @@
+# == Define: logstash::service::openbsd
+#
+# This class exists to coordinate all service management related actions,
+# functionality and logical units in a central place.
+#
+# <b>Note:</b> "service" is the Puppet term and type for background processes
+# in general and is used in a platform-independent way. E.g. "service" means
+# "daemon" in relation to Unix-like systems.
+#
+#
+# === Parameters
+#
+# ===== service_flags
+# String, used on OpenBSD to override/set the service flags, defaults to undef.
+#
+#
+# === Examples
+#
+# === Authors
+#
+# * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
+#
+define logstash::service::openbsd (
+  $service_flags = undef,
+){
+
+  #### Service management
+
+  # set params: in operation
+  if $logstash::ensure == 'present' {
+
+    case $logstash::status {
+      # make sure service is currently running, start it on boot
+      'enabled': {
+        $service_ensure = 'running'
+        $service_enable = true
+      }
+      # make sure service is currently stopped, do not start it on boot
+      'disabled': {
+        $service_ensure = 'stopped'
+        $service_enable = false
+      }
+      # make sure service is currently running, do not start it on boot
+      'running': {
+        $service_ensure = 'running'
+        $service_enable = false
+      }
+      # do not start service on boot, do not care whether currently running
+      # or not
+      'unmanaged': {
+        $service_ensure = undef
+        $service_enable = false
+      }
+      # unknown status
+      # note: don't forget to update the parameter check in init.pp if you
+      #       add a new or change an existing status.
+      default: {
+        fail("\"${logstash::status}\" is an unknown service status value")
+      }
+    }
+
+  # set params: removal
+  } else {
+
+    # make sure the service is stopped and disabled (the removal itself will be
+    # done by package.pp)
+    $service_ensure = 'stopped'
+    $service_enable = false
+
+  }
+
+  $notify_service = $logstash::restart_on_change ? {
+    true  => Service[$name],
+    false => undef,
+  }
+
+
+  if ( $logstash::status != 'unmanaged' ) {
+
+    # init file from template
+    if ($logstash::init_template != undef) {
+
+      file { "/etc/rc.d/${name}":
+        ensure  => $logstash::ensure,
+        content => template($logstash::init_template),
+        owner   => 'root',
+        group   => '0',
+        mode    => '0555',
+        before  => Service[$name],
+        notify  => $notify_service
+      }
+
+    }
+
+  }
+
+  # action
+  service { $name:
+    ensure     => $service_ensure,
+    enable     => $service_enable,
+    name       => $name,
+    flags      => $service_flags,
+    hasstatus  => $logstash::params::service_hasstatus,
+    hasrestart => $logstash::params::service_hasrestart,
+  }
+
+}

--- a/templates/etc/init.d/logstash.OpenBSD.erb
+++ b/templates/etc/init.d/logstash.OpenBSD.erb
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# This file is maintained via PUPPET
+
+daemon_user="_logstash"
+daemon="/usr/local/logstash/bin/logstash"
+daemon_flags="--config /etc/logstash/conf.d/ --log /var/log/logstash/logstash-<%= @name %>.log"
+
+. /etc/rc.d/rc.subr
+
+pexp="$(/usr/local/bin/javaPathHelper -c logstash).*logstash/runner.rb agent ${daemon_flags}"
+
+rc_reload=NO
+
+# Ensure _logstash can write to the logfile.
+# XXX: Remove on upgrade.
+rc_pre() {
+	chown -R _logstash:_logstash /var/log/logstash
+}
+
+rc_start() {
+	(${rcexec} "JAVA_HOME=\"$(/usr/local/bin/javaPathHelper -h logstash)\" \
+		JAVA_OPTS=\"${JAVA_OPTS} -Djava.library.path=/usr/local/jruby/lib/jni/x86_64-OpenBSD\" \
+		SINCEDB_DIR=\"/var/db/logstash\" \
+	   	     ${daemon} ${daemon_flags}") &
+}
+
+rc_cmd $1


### PR DESCRIPTION
- params.pp, add logstash_user/logstash_group, download_tool,
  and other variables relevant for OpenBSD
- init.pp: add service_flags parameter, for OpenBSD service
  flags, passed to service.pp, which passes them on to openbsd
  service file.
- manifests/service.pp: add a service_flags parameter,
  to be passed in for OpenBSD, and passed to the OpenBSD service
  class.
- manifests/service/openbsd.pp: new file, mostly copied from
  the init.pp file, defining related things for the OpenBSD service.
- templates/etc/init.d/logstash.OpenBSD.erb, new file,
  not used by default. basically a copy of the OpenBSD logstash rc file.

This is very similar to my Elasticsearch PR.
