### PR TITLE
fix SLES repo URL for logstash >= 1.5

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -58,7 +58,11 @@ class logstash::repo {
     'Suse' : {
       case $::operatingsystem {
         'SLES': {
-          $centos_version = 'centos5'
+          if versioncmp($logstash::repo_version, '1.5') >= 0 {
+            $centos_version = 'centos'
+          } else {
+            $centos_version = 'centos5'
+          }
           $gpg_key = 'GPG-KEY-elasticsearch-v3'
           $gpg_id = '465C1136'
         }


### PR DESCRIPTION
Minimal fix for the SLES repository. The "centos5" repository doesn't seem to exist for logstash>=1.5, but "centos" works. For logstash <=1.4 "centos5" is still used.