### PR TITLE
Fix service enable for RedHat osfamily 7

### DIFF
--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -126,7 +126,8 @@ define logstash::service::init{
 
   $service_provider = $::osfamily ? {
     'Debian' => 'debian',
-    default  => 'init'
+    'RedHat' => 'redhat',
+    default  => $logstash::service_provider,
   }
 
   # action

--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -126,7 +126,11 @@ define logstash::service::init{
 
   $service_provider = $::osfamily ? {
     'Debian' => 'debian',
-    'RedHat' => 'redhat',
+    'RedHat' => $::operatingsystemmajrelease ? {
+      '7'      => 'systemd',
+      /(5|6)/  => 'init',
+      undef    => 'init',
+    },
     default  => $logstash::service_provider,
   }
 

--- a/spec/classes/002_logstash_init_redhat_spec.rb
+++ b/spec/classes/002_logstash_init_redhat_spec.rb
@@ -287,7 +287,20 @@ describe 'logstash', :type => 'class' do
 
           context 'and default settings' do
 
-            it { should contain_service('logstash').with(:ensure => 'running') }
+            it { should contain_service('logstash').with(:ensure => 'running', :provider => 'init') }
+
+          end
+
+          context 'RHEl/CentOS 7' do
+
+            let :facts do {
+              :operatingsystem => distro,
+              :kernel => 'Linux',
+              :osfamily => 'RedHat',
+              :operatingsystemmajrelease => '7',
+            } end
+
+            it { should contain_service('logstash').with(:ensure => 'running', :provider => 'systemd') }
 
           end
 


### PR DESCRIPTION
This addresses #256 - it effectively sets the `serviceprovider` for RHEL/CentOS 7 to [systemd](https://docs.puppetlabs.com/references/latest/type.html#service-provider-systemd), which is the default provider for that `$::osfamily`.

This then ensures that the SystemD SYSV compatibility layer can correctly enable the service to start on boot.