### PR TITLE
Ensure we load only .conf files

### DIFF
--- a/templates/etc/init.d/logstash.Debian.erb
+++ b/templates/etc/init.d/logstash.Debian.erb
@@ -48,7 +48,7 @@ LS_JAVA_OPTS=" -Djava.io.tmpdir=/var/logstash/"
 LOG_DIR=/var/log/logstash
 
 # logstash configuration directory
-CONF_DIR=/etc/logstash/conf.d
+CONF_DIR="/etc/logstash/conf.d/*.conf"
 
 # logstash log file
 LOG_FILE=$LOG_DIR/$NAME.log

--- a/templates/etc/init.d/logstash.RedHat.erb
+++ b/templates/etc/init.d/logstash.RedHat.erb
@@ -44,7 +44,7 @@ LS_JAVA_OPTS="-Xmx256m -Djava.io.tmpdir=$LS_HOME/tmp"
 LOG_DIR=/var/log/logstash
 
 # logstash configuration directory
-CONF_DIR=/etc/logstash/conf.d
+CONF_DIR="/etc/logstash/conf.d/*.conf"
 
 # logstash log file
 LOG_FILE=$LOG_DIR/$NAME.log


### PR DESCRIPTION
We had a bug in our instances where some automated task was creating a Megasas.log file in the current path of the user logged in.
This was causing logstash not to start and we discovered that logstash tries to load all files in /etc/logstash/conf.d it would be nice if it only tried to load .conf files so we can avoid this kind of issues. 
