### PR TITLE
Only require logstash::package, not all of module

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -28,7 +28,7 @@ define logstash::plugin (
   $ensure = present,
 )
 {
-  require logstash
+  require logstash::package
   $exe = '/opt/logstash/bin/plugin'
 
   case $source { # Where should we get the plugin from?


### PR DESCRIPTION
Our config requires some plugins to be installed before starting logstash, otherwise startup fails.

If I try and add ``notify => Class['logstash::service']`` to the ``logstash::plugin`` resources, I end up with a circular dependency reference:

``(Anchor[logstash::end] => Class[Logstash] => Logstash::Plugin[logstash-filter-translate] => Exec[install-logstash-filter-translate] => Logstash::Plugin[logstash-filter-translate] => Service[logstash] => Logs
tash::Service::Init[logstash] => Class[Logstash::Service] => Anchor[logstash::end])``

All we need to install plugins is have the package installed - so only require ``logstash::package`` to be run, rather than requiring ``logstash`` and all of it's dependency settings.