### PR TITLE
Ensure tests run against $LS_VERSION.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ ruby '1.9.3'
 puppetversion = ENV['PUPPET_VERSION'] || '3.8.6'
 gem 'puppet', puppetversion, :require => false
 
-gem 'beaker'
-gem 'beaker-rspec'
+gem 'beaker', '2.34.0'
+gem 'beaker-rspec', '5.3.0'
 
 # REF: https://github.com/voxpupuli/metadata-json-lint/issues/10
 # gem 'metadata-json-lint'
@@ -27,7 +27,8 @@ gem 'puppetlabs_spec_helper'
 gem 'puppet-syntax'
 gem 'rspec-puppet-facts'
 gem 'rubocop'
-gem 'serverspec'
+gem 'serverspec', '2.34.0'
+gem 'specinfra', '2.57.2'
 gem 'webmock'
 gem 'redcarpet'
 

--- a/spec/acceptance/class_logstash_spec.rb
+++ b/spec/acceptance/class_logstash_spec.rb
@@ -49,7 +49,7 @@ describe 'class logstash' do
     context 'when installing from an http url' do
       before(:all) do
         remove_logstash
-        install_logstash("package_url => '#{logstash_package_url}'")
+        install_logstash_from_url(http_package_url)
       end
 
       it_behaves_like 'a logstash installer'
@@ -67,9 +67,7 @@ describe 'class logstash' do
     context 'when installing from a "puppet://" url' do
       before(:all) do
         remove_logstash
-        install_logstash(
-          "package_url => 'puppet:///modules/logstash/#{logstash_package_filename}'"
-        )
+        install_logstash_from_url(puppet_fileserver_package_url)
       end
 
       it_behaves_like 'a logstash installer'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -110,6 +110,10 @@ def install_logstash_from_url_manifest(url, extra_args = nil)
   END
 end
 
+def install_logstash_from_local_file_manifest(extra_args = nil)
+  install_logstash_from_url_manifest(local_file_package_url, extra_args)
+end
+
 def remove_logstash_manifest
   <<-END
   class { 'logstash':

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -68,10 +68,10 @@ def logstash_package_filename
 end
 
 def logstash_package_version
-  case fact('osfamily')
-  when 'RedHat', 'Suse'
+  case fact('osfamily') # FIXME: Put this logic in the module, not the tests.
+  when 'RedHat'
     "#{LS_VERSION}-1"
-  when 'Debian'
+  when 'Debian', 'Suse'
     "1:#{LS_VERSION}-1"
   end
 end


### PR DESCRIPTION
Some acceptance tests were installing the latest version of Logstash, instead of the version specified by $LS_VERSION.