### PR TITLE
fix deprecate include_src

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -36,12 +36,14 @@ class logstash::repo {
       require apt
 
       apt::source { 'logstash':
-        location    => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
-        release     => 'stable',
-        repos       => 'main',
-        key         => 'D88E42B4',
-        key_source  => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
-        include_src => false,
+        location   => "http://packages.elasticsearch.org/logstash/${logstash::repo_version}/debian",
+        release    => 'stable',
+        repos      => 'main',
+        key        => 'D27D666CD88E42B4',
+        key_source => 'http://packages.elasticsearch.org/GPG-KEY-elasticsearch',
+        include    => {
+          src      => false,
+        }
       }
     }
     'RedHat': {


### PR DESCRIPTION
Fix
'WARNING: $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead'

Also add the full key id