### PR TITLE
Acceptance tests currently fail, and don't test current logstash.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
 env:
   global:
     - TRAVIS_CI=true
-    - LOGSTASH_VERSION=2.3.4
+    - LOGSTASH_VERSION=2.4.0
     - BEAKER_PE_DIR=spec/fixtures/artifacts
   matrix:
     # Run the unit tests once.
@@ -47,7 +47,9 @@ env:
 
     - PUPPET_VERSION=3.8.6 BEAKER_set=debian-7
     - PUPPET_VERSION=4.4.2 BEAKER_set=debian-7
-    - PUPPET_VERSION=3.8.4 BEAKER_set=debian-7 BEAKER_PE_VER=3.8.4 BEAKER_IS_PE=true
+    # FIXME: Beaker fails to install PE on Debian 7.
+    # Example: https://travis-ci.org/elastic/puppet-logstash/jobs/159507699#L542
+    # - PUPPET_VERSION=3.8.4 BEAKER_set=debian-7 BEAKER_PE_VER=3.8.4 BEAKER_IS_PE=true
 
     - PUPPET_VERSION=3.8.6 BEAKER_set=debian-8
     - PUPPET_VERSION=4.4.2 BEAKER_set=debian-8
@@ -64,3 +66,4 @@ env:
     - PUPPET_VERSION=4.4.2 BEAKER_set=ubuntu-1404 LOGSTASH_VERSION=2.1.2
     - PUPPET_VERSION=4.4.2 BEAKER_set=ubuntu-1404 LOGSTASH_VERSION=2.2.4
     - PUPPET_VERSION=4.4.2 BEAKER_set=ubuntu-1404 LOGSTASH_VERSION=2.3.4
+    - PUPPET_VERSION=4.4.2 BEAKER_set=ubuntu-1404 LOGSTASH_VERSION=2.4.0

--- a/spec/acceptance/00_meta_spec.rb
+++ b/spec/acceptance/00_meta_spec.rb
@@ -14,7 +14,7 @@ end
 describe 'logstash module' do
   it 'should be available' do
     shell(
-      "ls #{default['distmoduledir']}/logstash/Modulefile",
+      "ls #{default['distmoduledir']}/logstash/metadata.json",
       acceptable_exit_codes: 0
     )
   end

--- a/spec/acceptance/nodesets/centos-6-docker.yml
+++ b/spec/acceptance/nodesets/centos-6-docker.yml
@@ -2,7 +2,7 @@ HOSTS:
   centos-6-x64:
     roles: [agent, database, dashboard, master]
     platform: el-6-x86_64
-    image: electrical/centos:6.4
+    image: centos:6
     hypervisor: docker
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -45,13 +45,21 @@ def expect_no_change_from_manifest(manifest)
 end
 
 def http_package_url
-  url_root = 'http://download.elasticsearch.org/logstash/logstash/packages'
+  url_root = 'https://download.elastic.co/logstash/logstash/packages'
+
+  #older (but supported) versions have slightly different file numbers
+  sep = Hash.new('-')
+  trail = Hash.new('')
+  ["2.1.2", "2.2.4", "2.3.4"].each do |old_version|
+    sep[old_version] = "_"
+    trail[old_version] = "-1"
+  end
 
   case fact('osfamily')
   when 'Debian'
-    "#{url_root}/debian/logstash_#{LS_VERSION}-1_all.deb"
+    "#{url_root}/debian/logstash#{sep[LS_VERSION]}#{LS_VERSION}#{trail[LS_VERSION]}_all.deb"
   when 'RedHat', 'Suse'
-    "#{url_root}/centos/logstash-#{LS_VERSION}-1.noarch.rpm"
+    "#{url_root}/centos/logstash-#{LS_VERSION}#{trail[LS_VERSION]}.noarch.rpm"
   end
 end
 


### PR DESCRIPTION
Hi, without any changes the acceptance tests as run by Travis currently fail. I've tried to patch them up here and got most of them going, and also test logstash 2.4.0.

I've got a few which tests which still fail. I'm not sure about the jopenssl errors for Centos 6. It almost looks like logstash doesn't work for this distro, but it seems to be supported on the Elastic support matrix.

Puppet Enterprise seems to fail to install on Debian 7. If this is the case should it be dropped from the
test matrix?

And logstash versions 2.1.2, 2.2.4 and 2.3.4 don't seem to be available at download.elastic.co. I'm not sure what to do about that either.

