### PR TITLE
Added package_name parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,9 @@
 # [*package_dir*]
 #   Directory where the packages are downloaded to
 #
+# [*package_name*]
+#   Logstash packagename
+#
 # [*purge_package_dir*]
 #   Purge package directory on removal
 #
@@ -156,6 +159,7 @@ class logstash(
   $software_provider   = 'package',
   $package_url         = undef,
   $package_dir         = $logstash::params::package_dir,
+  $package_name        = $logstash::params::package_name,
   $purge_package_dir   = $logstash::params::purge_package_dir,
   $package_dl_timeout  = $logstash::params::package_dl_timeout,
   $logstash_user       = $logstash::params::logstash_user,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -73,7 +73,8 @@ class logstash::package {
 
   #class { 'logstash::package::core': }
   logstash::package::install { 'logstash':
-    package_url => $logstash::package_url,
-    version     => $logstash::version,
+    package_url  => $logstash::package_url,
+    version      => $logstash::version,
+    package_name => $logstash::package_name,
   }
 }

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -29,7 +29,8 @@
 #
 define logstash::package::install(
   $package_url = undef,
-  $version = undef
+  $version = undef,
+  $package_name = undef,
 ) {
 
   Exec {
@@ -153,6 +154,7 @@ define logstash::package::install(
 
     package { $name:
       ensure   => $package_ensure,
+      name     => $package_name,
       source   => $pkg_source,
       provider => $pkg_provider,
       tag      => 'logstash',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,13 +115,13 @@ class logstash::params {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLES', 'OpenSuSE': {
       # main application
       $package = [ 'logstash' ],
-      $package_name = 'logstash',
+      $package_name = 'logstash'
       $contrib = [ 'logstash-contrib' ]
     }
     'Debian', 'Ubuntu': {
       # main application
       $package = [ 'logstash' ]
-      $package_name = 'logstash',
+      $package_name = 'logstash'
       $contrib = [ 'logstash-contrib' ]
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -114,7 +114,7 @@ class logstash::params {
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLES', 'OpenSuSE': {
       # main application
-      $package = [ 'logstash' ],
+      $package = [ 'logstash' ]
       $package_name = 'logstash'
       $contrib = [ 'logstash-contrib' ]
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -114,12 +114,14 @@ class logstash::params {
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Fedora', 'Scientific', 'Amazon', 'OracleLinux', 'SLES', 'OpenSuSE': {
       # main application
-      $package = [ 'logstash' ]
+      $package = [ 'logstash' ],
+      $package_name = 'logstash',
       $contrib = [ 'logstash-contrib' ]
     }
     'Debian', 'Ubuntu': {
       # main application
       $package = [ 'logstash' ]
+      $package_name = 'logstash',
       $contrib = [ 'logstash-contrib' ]
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -161,5 +161,4 @@ class logstash::params {
             for \"${::operatingsystem}\"")
     }
   }
-
 }


### PR DESCRIPTION
That will enable user to install non default package name like
logstash-all-plugins.

---------------------
sudo puppet apply -e "package{'logstash': ensure => present, provider => rpm, source=> 'http://ord-repo-001.ludia.me/misc/logstash-all-plugins-2.4.0.noarch.rpm',}"
---------------------
I'll get that error:
Error: Execution of '/usr/bin/rpm -i http://ord-repo-001.ludia.me/misc/logstash-all-plugins-2.4.0.noarch.rpm' returned 1: package logstash-all-plugins-1:2.4.0-1.noarch is already installed
Error: /Stage[main]/Main/Package[logstash]/ensure: change from absent to present failed: Execution of '/usr/bin/rpm -i http://ord-repo-001.ludia.me/misc/logstash-all-plugins-2.4.0.noarch.rpm' returned 1: package logstash-all-plugins-1:2.4.0-1.noarch is already installed

It is happening, because puppet is checking for 'logstash' rpm and as it is not installed, will try to install logstash-all-plugins-2.4.0.noarch.rpm (but it is already installed.

My solution will include the parameter 'name' from logstash::package_name and:

----------------------------------------
sudo puppet apply -e "package{'logstash': name => 'logstash-all-plugins', provider => rpm, source=> 'http://ord-repo-001.ludia.me/misc/logstash-all-plugins-2.4.0.noarch.rpm',}"
----------------------------------------

Notice: Compiled catalog for test.foo.me in environment production in 0.53 seconds
Notice: Finished catalog run in 0.78 seconds

