### PR TITLE
Fix ownership of `/etc/logstash`

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,7 +36,8 @@ class logstash::config {
   }
 
   File {
-    owner => $logstash::logstash_user,
-    group => $logstash::logstash_group,
+    owner => 'root',
+    group => 'root',
+    mode  => '0755',
   }
 }

--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -40,9 +40,9 @@ define logstash::configfile(
   include logstash
 
   $path = "${logstash::config_dir}/conf.d/${name}"
-  $owner = $logstash::logstash_user
-  $group = $logstash::logstash_group
-  $mode ='0440'
+  $owner = 'root'
+  $group = 'root'
+  $mode  = '0644'
   $require = Package['logstash'] # So that we have '/etc/logstash/conf.d'.
   $tag = [ 'logstash_config' ] # So that we notify the service.
 

--- a/manifests/patternfile.pp
+++ b/manifests/patternfile.pp
@@ -32,8 +32,8 @@ define logstash::patternfile ($source = undef, $filename = undef) {
   file { "${logstash::config_dir}/patterns/${destination}":
     ensure => file,
     source => $source,
-    owner  => $logstash::logstash_user,
-    group  => $logstash::logstash_group,
+    owner  => 'root',
+    group  => 'root',
     mode   => '0644',
     tag    => ['logstash_config'],
   }


### PR DESCRIPTION
`/etc/logstash` definitely needs to be readable by the `logstash` user, but it doesn't need to be writable by the same user. Specifically, when installing `Package['logstash']` manually, `/etc/logstash` is owned by `root:root` rather than `logstash:logstash`.