### PR TITLE
Parameterize Logstash home directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,6 +159,8 @@ class logstash(
     fail("\"${status}\" is not a valid status parameter value")
   }
 
+  $home_dir = '/usr/share/logstash'
+
   if ($manage_repo == true) {
     validate_string($repo_version)
     include logstash::repo

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -31,7 +31,7 @@ define logstash::plugin (
 )
 {
   require logstash::package
-  $exe = '/usr/share/logstash/bin/logstash-plugin'
+  $exe = "${logstash::home_dir}/bin/logstash-plugin"
 
   case $source { # Where should we get the plugin from?
     undef: {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,7 +17,7 @@ class logstash::service {
 
   $default_startup_options = {
     'JAVACMD'             => '/usr/bin/java',
-    'LS_HOME'             => '/usr/share/logstash',
+    'LS_HOME'             => $logstash::home_dir,
     'LS_SETTINGS_DIR'     => $logstash::config_dir,
     'LS_OPTS'             => "--path.settings=${logstash::config_dir}",
     'LS_JAVA_OPTS'        => '""',
@@ -90,7 +90,7 @@ class logstash::service {
     # Invoke 'system-install', which generates startup scripts based on the
     # contents of the 'startup.options' file.
     exec { 'logstash-system-install':
-      command     => '/usr/share/logstash/bin/system-install',
+      command     => "${logstash::home_dir}/bin/system-install",
       refreshonly => true,
       notify      => Service['logstash'],
     }


### PR DESCRIPTION
Define `$logstash::home_dir = '/usr/share/logstash'` to avoid needless repetition.