### PR TITLE
Fixes for Puppet 4 strict_variables

### DIFF
--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -48,6 +48,7 @@ define logstash::configfile(
 
   if($template)   { $config = template($template) }
   elsif($content) { $config = $content }
+  else            { $config = undef }
 
   if($config){
     file { $path:

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -70,6 +70,8 @@ class logstash::package(
         'rpm':   { $package_provider = 'rpm'   }
         default: { fail("Unknown file extension '${extension}'.") }
       }
+
+      $package_require = undef
     }
     else {
       # Use the OS packaging system to locate the package.
@@ -77,11 +79,14 @@ class logstash::package(
       $package_provider = undef
       if $::osfamily == 'Debian' {
         $package_require = Class['apt::update']
+      } else {
+        $package_require = undef
       }
     }
   }
   else { # Package removal
     $package_local_file = undef
+    $package_require = undef
     if ($::osfamily == 'Suse') {
       $package_provider = 'rpm'
       $package_ensure = 'absent' # "purged" not supported by provider


### PR DESCRIPTION
Add default values for variables that break compilation when strict_variables is enabled in Puppet 4