### PR TITLE
Allow file:/// paths

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -40,10 +40,11 @@ define logstash::plugin (
       $plugin = $name
     }
 
-    /^\//: {
+    /^(\/|file:)/: {
       # A gem file that is already available on the local filesystem.
       # Install from the local path.
-      # ie. "logstash-plugin install /tmp/logtash-filter-custom.gem"
+      # ie. "logstash-plugin install /tmp/logtash-filter-custom.gem" or
+      # "logstash-plugin install file:///tmp/logtash-filter-custom.gem" or
       $plugin = $source
     }
 


### PR DESCRIPTION
This is what the underlying logstash-plugin install call expects if
retrieving from the local filesystem, else it attempts to contact the
internet for retrieval as a gem.

If you pass /opt/elasticsearch/swdl/x-pack-5.2.2.zip as a location on the filesystem it attempts to retreieve from the internet:
```Validating /opt/elasticsearch/swdl/x-pack-5.2.2.zip
Unable to download data from https://rubygems.org - SocketError: Network is unreachable (https://api.rubygems.org/latest_specs.4.8.gz)
ERROR: Installation aborted, verification failed for /opt/elasticsearch/swdl/x-pack-5.2.2.zip```

This is aligned with the documentation upstream: https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-installing-offline which says to use file:///