### PR TITLE
Add Archlinux support + purge validate_* function calls

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,9 @@
 fixtures:
   repositories:
     stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
+      repo: "git@github.com:puppetlabs/puppetlabs-stdlib.git"
       ref: "3.2.0"
-    apt: git://github.com/puppetlabs/puppetlabs-apt.git
-    zypprepo: https://github.com/deadpoint/puppet-zypprepo.git
+    apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
+    zypprepo: "git@github.com:deadpoint/puppet-zypprepo.git"
   symlinks:
     logstash: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,9 @@
 fixtures:
   repositories:
     stdlib:
-      repo: "git@github.com:puppetlabs/puppetlabs-stdlib.git"
+      repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref: "3.2.0"
     apt: "git://github.com/puppetlabs/puppetlabs-apt.git"
-    zypprepo: "git@github.com:deadpoint/puppet-zypprepo.git"
+    zypprepo: "git://github.com/deadpoint/puppet-zypprepo.git"
   symlinks:
     logstash: "#{source_dir}"

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,7 @@ env:
     - TRAVIS_LINT=true
 
     # Then run the acceptance tests across the matrix.
-    - PUPPET_VERSION=3.8.7 BEAKER_set=centos-6
     - PUPPET_VERSION=4.8.2 BEAKER_set=centos-6
-    # - PUPPET_VERSION=3.8.4 BEAKER_set=centos-6 BEAKER_PE_VER=3.8.4 BEAKER_IS_PE=true
-
-    - PUPPET_VERSION=3.8.7 BEAKER_set=centos-7
     - PUPPET_VERSION=4.0.0 BEAKER_set=centos-7
     - PUPPET_VERSION=4.1.0 BEAKER_set=centos-7
     - PUPPET_VERSION=4.2.3 BEAKER_set=centos-7
@@ -49,24 +45,12 @@ env:
     - PUPPET_VERSION=4.7.0 BEAKER_set=centos-7
     - PUPPET_VERSION=4.8.2 BEAKER_set=centos-7
     - PUPPET_VERSION=4.9.4 BEAKER_set=centos-7
-
-    - PUPPET_VERSION=3.8.7 BEAKER_set=debian-7
     - PUPPET_VERSION=4.8.2 BEAKER_set=debian-7
-    # - PUPPET_VERSION=3.8.4 BEAKER_set=debian-7 BEAKER_PE_VER=3.8.4 BEAKER_IS_PE=true
-
-    - PUPPET_VERSION=3.8.7 BEAKER_set=debian-8
     - PUPPET_VERSION=4.8.2 BEAKER_set=debian-8
     - PUPPET_VERSION=4.9.4 BEAKER_set=debian-8
-
-    - PUPPET_VERSION=3.8.7 BEAKER_set=opensuse-13
-
-    - PUPPET_VERSION=3.8.7 BEAKER_set=ubuntu-1204
     - PUPPET_VERSION=4.8.2 BEAKER_set=ubuntu-1204
     - PUPPET_VERSION=4.9.4 BEAKER_set=ubuntu-1204
-
-    - PUPPET_VERSION=3.8.7 BEAKER_set=ubuntu-1404
     - PUPPET_VERSION=4.8.2 BEAKER_set=ubuntu-1404
     - PUPPET_VERSION=4.9.4 BEAKER_set=ubuntu-1404
-
     - PUPPET_VERSION=4.8.2 BEAKER_set=ubuntu-1604
     - PUPPET_VERSION=4.9.4 BEAKER_set=ubuntu-1604

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby '2.2.5'
 
 puppetversion = ENV['PUPPET_VERSION'] || '4.8.1'
 gem 'puppet', puppetversion, :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-puppetversion = ENV['PUPPET_VERSION'] || '4.8.1'
+puppetversion = ENV['PUPPET_VERSION'] || '~> 4.0'
 gem 'puppet', puppetversion, :require => false
 
 gem 'beaker', '3.13.0'

--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -48,6 +48,7 @@ define logstash::configfile(
 
   if($template)   { $config = template($template) }
   elsif($content) { $config = $content }
+  else            { $config = undef }
 
   if($config){
     file { $path:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,32 +122,27 @@
 # @author https://github.com/elastic/puppet-logstash/graphs/contributors
 #
 class logstash(
-  $ensure            = 'present',
-  $status            = 'enabled',
-  $restart_on_change = true,
-  $auto_upgrade       = false,
-  $version           = undef,
-  $package_url       = undef,
-  $package_name      = 'logstash',
-  $download_timeout  = 600,
-  $logstash_user     = 'logstash',
-  $logstash_group    = 'logstash',
-  $config_dir         = '/etc/logstash',
-  $purge_config      = true,
-  $service_provider  = undef,
-  $settings          = {},
-  $startup_options   = {},
-  $jvm_options       = [],
-  $manage_repo       = $logstash::params::manage_repo,
-  $repo_version      = '5.x',
+  $ensure                    = 'present',
+  $status                    = 'enabled',
+  Boolean $restart_on_change = true,
+  Boolean $auto_upgrade      = false,
+  $version                   = undef,
+  $package_url               = undef,
+  $package_name              = 'logstash',
+  $download_timeout          = 600,
+  $logstash_user             = 'logstash',
+  $logstash_group            = 'logstash',
+  $config_dir                = '/etc/logstash',
+  Boolean $purge_config      = true,
+  $service_provider          = undef,
+  $settings                  = {},
+  $startup_options           = {},
+  $jvm_options               = [],
+  Boolean $manage_repo       = $logstash::params::manage_repo,
+  String $repo_version              = '5.x',
 ) inherits logstash::params
 {
-  $home_dir = '/usr/share/logstash'
-
-  validate_bool($auto_upgrade)
-  validate_bool($restart_on_change)
-  validate_bool($purge_config)
-  validate_bool($manage_repo)
+  $home_dir                  = '/usr/share/logstash'
 
   if ! ($ensure in [ 'present', 'absent' ]) {
     fail("\"${ensure}\" is not a valid ensure parameter value")
@@ -163,7 +158,6 @@ class logstash(
 
 
   if ($manage_repo == true) {
-    validate_string($repo_version)
     include logstash::repo
   }
   include logstash::package

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,9 +138,9 @@ class logstash(
   $settings          = {},
   $startup_options   = {},
   $jvm_options       = [],
-  $manage_repo       = true,
+  $manage_repo       = $logstash::params::manage_repo,
   $repo_version      = '5.x',
-)
+) inherits logstash::params
 {
   $home_dir = '/usr/share/logstash'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,42 +122,29 @@
 # @author https://github.com/elastic/puppet-logstash/graphs/contributors
 #
 class logstash(
-  $ensure                    = 'present',
-  $status                    = 'enabled',
-  Boolean $restart_on_change = true,
-  Boolean $auto_upgrade      = false,
-  $version                   = undef,
-  $package_url               = undef,
-  $package_name              = 'logstash',
-  $download_timeout          = 600,
-  $logstash_user             = 'logstash',
-  $logstash_group            = 'logstash',
-  $config_dir                = '/etc/logstash',
-  Boolean $purge_config      = true,
-  $service_provider          = undef,
-  $settings                  = {},
-  $startup_options           = {},
-  $jvm_options               = [],
-  Boolean $manage_repo       = $logstash::params::manage_repo,
-  String $repo_version              = '5.x',
+  Enum['present','absent'] $ensure                         = 'present',
+  Enum['enabled','disabled','running','unmanaged'] $status = 'enabled',
+  Boolean $restart_on_change                               = true,
+  Boolean $auto_upgrade                                    = false,
+  $version                                                 = undef,
+  $package_url                                             = undef,
+  $package_name                                            = 'logstash',
+  Integer $download_timeout                                = 600,
+  $logstash_user                                           = 'logstash',
+  $logstash_group                                          = 'logstash',
+  $config_dir                                              = '/etc/logstash',
+  Boolean $purge_config                                    = true,
+  $service_provider                                        = undef,
+  $settings                                                = {},
+  $startup_options                                         = {},
+  $jvm_options                                             = [],
+  Boolean $manage_repo                                     = $logstash::params::manage_repo,
+  String $repo_version                                     = '5.x',
 ) inherits logstash::params
 {
-  $home_dir                  = '/usr/share/logstash'
+  $home_dir                                                = '/usr/share/logstash'
 
-  if ! ($ensure in [ 'present', 'absent' ]) {
-    fail("\"${ensure}\" is not a valid ensure parameter value")
-  }
-
-  if ! is_integer($download_timeout) {
-    fail("\"${download_timeout}\" is not a valid number for 'download_timeout' parameter")
-  }
-
-  if ! ($status in [ 'enabled', 'disabled', 'running', 'unmanaged' ]) {
-    fail("\"${status}\" is not a valid status parameter value")
-  }
-
-
-  if ($manage_repo == true) {
+  if $manage_repo {
     include logstash::repo
   }
   include logstash::package

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -70,6 +70,8 @@ class logstash::package(
         'rpm':   { $package_provider = 'rpm'   }
         default: { fail("Unknown file extension '${extension}'.") }
       }
+
+      $package_require = undef
     }
     else {
       # Use the OS packaging system to locate the package.
@@ -77,11 +79,14 @@ class logstash::package(
       $package_provider = undef
       if $::osfamily == 'Debian' {
         $package_require = Class['apt::update']
+      } else {
+        $package_require = undef
       }
     }
   }
   else { # Package removal
     $package_local_file = undef
+    $package_require = undef
     if ($::osfamily == 'Suse') {
       $package_provider = 'rpm'
       $package_ensure = 'absent' # "purged" not supported by provider

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,10 @@
+class logstash::params {
+  case $facts['os']['family'] {
+    'Archlinux': {
+      $manage_repo = false
+    }
+    default: {
+      $manage_repo = true
+    }
+  }
+}

--- a/manifests/patternfile.pp
+++ b/manifests/patternfile.pp
@@ -19,15 +19,17 @@
 #
 # @author https://github.com/elastic/puppet-logstash/graphs/contributors
 #
-define logstash::patternfile ($source = undef, $filename = undef) {
+define logstash::patternfile (
+  Pattern[/^(puppet|file):\/\//] $source = undef,
+  $filename = undef
+) {
   require logstash::config
 
-  validate_re($source, '^(puppet|file)://',
-    'Source must begin with "puppet://" or "file://")'
-  )
-
-  if($filename) { $destination = $filename }
-  else          { $destination = basename($source) }
+  if($filename) {
+    $destination = $filename
+  }  else {
+    $destination = basename($source)
+  }
 
   file { "${logstash::config_dir}/patterns/${destination}":
     ensure => file,

--- a/manifests/patternfile.pp
+++ b/manifests/patternfile.pp
@@ -21,7 +21,7 @@
 #
 define logstash::patternfile (
   Pattern[/^(puppet|file):\/\//] $source = undef,
-  $filename = undef
+  String $filename                       = undef
 ) {
   require logstash::config
 

--- a/metadata.json
+++ b/metadata.json
@@ -62,6 +62,9 @@
       "operatingsystemrelease": [
         "13.x"
       ]
+    },
+    {
+      "operatingsystem": "Archlinux"
     }
   ],
   "requirements": [

--- a/metadata.json
+++ b/metadata.json
@@ -70,7 +70,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.8.0 <5.0.0"
+      "version_requirement": ">= 4.6.1 < 5.0.0"
     }
   ]
 }

--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,0 +1,4 @@
+require 'rspec-puppet'
+
+at_exit { RSpec::Puppet::Coverage.report! }
+# vim: syntax=ruby

--- a/spec/classes/logstash_spec.rb
+++ b/spec/classes/logstash_spec.rb
@@ -11,6 +11,19 @@ describe 'logstash' do
       end
       context 'with all defaults' do
         it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('logstash') }
+        it { is_expected.to contain_class('logstash::config') }
+        it { is_expected.to contain_class('logstash::package') }
+        it { is_expected.to contain_class('logstash::params') }
+        it { is_expected.to contain_class('logstash::service') }
+        it { is_expected.to contain_file('/etc/logstash/conf.d') }
+        it { is_expected.to contain_file('/etc/logstash/jvm.options') }
+        it { is_expected.to contain_file('/etc/logstash/logstash.yml') }
+        it { is_expected.to contain_file('/etc/logstash/patterns') }
+        it { is_expected.to contain_file('/etc/logstash/startup.options') }
+        it { is_expected.to contain_file('/etc/logstash') }
+        it { is_expected.to contain_service('logstash') }
+        it { is_expected.to contain_package('logstash') }
       end
     end
   end

--- a/spec/classes/logstash_spec.rb
+++ b/spec/classes/logstash_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe 'logstash' do
+  let :node do
+    'agent.example.com'
+  end
+  on_supported_os.each do |os, facts|
+    context "on #{os} " do
+      let :facts do
+        facts
+      end
+      context 'with all defaults' do
+        it { is_expected.to compile.with_all_deps }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,11 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 RSpec.configure do |c|
-  Puppet.settings[:strict_variables]=true if ENV['STRICT_VARIABLES'] == 'true'
-  Puppet.settings[:ordering]='random' if ENV['ORDERING_RANDOM'] == 'true'
-  c.parser = 'future' if ENV['FUTURE_PARSER'] == 'true'
+  default_facts = {
+    puppetversion: Puppet.version,
+    facterversion: Facter.version
+  }
+  c.default_facts = default_facts
 end


### PR DESCRIPTION
Hi,

I introduce a few things here. Let me know if you would prefer them in separate pull requests:

* Archlinux support
* basic spec tests
* strict_variables support from https://github.com/elastic/puppet-logstash/pull/330
* puppet4 datatypes to replace legacy validate_* function calls