### PR TITLE
add package config purging option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ clean:
 	rm -f files/*.gem
 	rm -f files/*.rpm
 	rm -rf log
+	rm -rf pkg
 
 release: clean
 	puppet module build

--- a/README.md
+++ b/README.md
@@ -1,8 +1,25 @@
-# puppet-logstash
+# elasticsearch/puppet-logstash
 
-A Puppet module for managing and configuring [Logstash](http://logstash.net/).
+Legacy module for managing [Logstash](http://logstash.net/) 2.x.
 
-[![Build Status](https://travis-ci.org/elastic/puppet-logstash.png?branch=master)](https://travis-ci.org/elastic/puppet-logstash)
+This module is no longer under active development. See below...
+
+## Deprecation warning
+
+This version of the module only supports Logstash 2.x.
+
+* It is available on [Puppet Forge](https://forge.puppet.com/elasticsearch/logstash)
+as "`elasticsearch/logstash`".
+* The source is kept on the ["2.x" branch of the GitHub repository](https://github.com/elastic/puppet-logstash/tree/2.x).
+
+For Logstash 5.x, and a better experience in general, a heavily rewritten
+module is available:
+
+* On [Puppet Forge](https://forge.puppet.com/elastic/logstash) as
+"`elastic/logstash`".
+* In the `master` branch of the [GitHub repository](https://github.com/elastic/puppet-logstash/tree/master).
+
+[![Build Status](https://travis-ci.org/elastic/puppet-logstash.png?branch=2.x)](https://travis-ci.org/elastic/puppet-logstash)
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# elasticsearch/puppet-logstash
+# elasticsearch/logstash
 
 Legacy module for managing [Logstash](http://logstash.net/) 2.x.
 
@@ -8,16 +8,14 @@ This module is no longer under active development. See below...
 
 This version of the module only supports Logstash 2.x.
 
-* It is available on [Puppet Forge](https://forge.puppet.com/elasticsearch/logstash)
-as "`elasticsearch/logstash`".
-* The source is kept on the ["2.x" branch of the GitHub repository](https://github.com/elastic/puppet-logstash/tree/2.x).
+* It is available on Puppet Forge as "[`elasticsearch/logstash`](https://forge.puppet.com/elasticsearch/logstash)".
+* The source is kept on the [`2.x` branch of the GitHub repository](https://github.com/elastic/puppet-logstash/tree/2.x).
 
 For Logstash 5.x, and a better experience in general, a heavily rewritten
 module is available:
 
-* On [Puppet Forge](https://forge.puppet.com/elastic/logstash) as
-"`elastic/logstash`".
-* In the `master` branch of the [GitHub repository](https://github.com/elastic/puppet-logstash/tree/master).
+* On Puppet Forge as "[`elastic/logstash`](https://forge.puppet.com/elastic/logstash)".
+* In the [`master` branch of the GitHub repository](https://github.com/elastic/puppet-logstash/tree/master).
 
 [![Build Status](https://travis-ci.org/elastic/puppet-logstash.png?branch=2.x)](https://travis-ci.org/elastic/puppet-logstash)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,11 @@
 #   Path to directory containing the logstash configuration.
 #   Use this setting if your packages deviate from the norm (/etc/logstash)
 #
+# [*package_configfiles*]
+#   Whether to keep or replace modified config files when installing or upgrading a package. 
+#   This only affects the apt and dpkg providers. Defaults to keep.
+#   Valid values are keep, replace.
+
 # === Examples
 #
 # * Installation, make sure service is running and will be started at boot time:
@@ -166,6 +171,7 @@ class logstash(
   $logstash_group      = $logstash::params::logstash_group,
   $configdir           = $logstash::params::configdir,
   $purge_configdir     = $logstash::params::purge_configdir,
+  $package_configfiles = 'keep',
   $java_install        = false,
   $java_package        = undef,
   $service_provider    = 'init',
@@ -222,7 +228,9 @@ class logstash(
   #### Manage actions
 
   # package(s)
-  class { 'logstash::package': }
+  class { 'logstash::package':
+    package_configfiles => $package_configfiles,
+  }
 
   # configuration
   class { 'logstash::config': }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -6,7 +6,10 @@
 #
 # === Parameters
 #
-# This class does not provide any parameters.
+# [*package_configfiles*]
+#   Whether to keep or replace modified config files when installing or upgrading a package.
+#   This only affects the apt and dpkg providers. Defaults to keep.
+#   Valid values are keep, replace.
 #
 #
 # === Examples
@@ -22,7 +25,9 @@
 #
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
-class logstash::package {
+class logstash::package(
+  $package_configfiles = 'keep',
+){
 
   Exec {
     path      => [ '/bin', '/usr/bin', '/usr/local/bin' ],
@@ -73,8 +78,9 @@ class logstash::package {
 
   #class { 'logstash::package::core': }
   logstash::package::install { 'logstash':
-    package_url  => $logstash::package_url,
-    version      => $logstash::version,
-    package_name => $logstash::package_name,
+    package_url         => $logstash::package_url,
+    version             => $logstash::version,
+    package_name        => $logstash::package_name,
+    package_configfiles => $package_configfiles,
   }
 }

--- a/manifests/package/install.pp
+++ b/manifests/package/install.pp
@@ -31,6 +31,7 @@ define logstash::package::install(
   $package_url = undef,
   $version = undef,
   $package_name = undef,
+  $package_configfiles = 'keep',
 ) {
 
   Exec {
@@ -153,11 +154,12 @@ define logstash::package::install(
   if ($logstash::software_provider == 'package') {
 
     package { $name:
-      ensure   => $package_ensure,
-      name     => $package_name,
-      source   => $pkg_source,
-      provider => $pkg_provider,
-      tag      => 'logstash',
+      ensure      => $package_ensure,
+      name        => $package_name,
+      source      => $pkg_source,
+      provider    => $pkg_provider,
+      tag         => 'logstash',
+      configfiles => $package_configfiles,
     }
 
   } else {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-logstash",
-  "version": "0.6.4",
+  "version": "0.6.6",
   "source": "https://github.com/elastic/puppet-logstash",
   "author": "elasticsearch",
   "license": "Apache-2.0",


### PR DESCRIPTION
Expose a parameter to support replacing or keeping existing config files for debian package upgrades.

Otherwise, important files like `/etc/init.d/logstash` do not get updated.