### PR TITLE
Reload logstash when purging files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,6 +29,7 @@ class logstash::config {
       purge   => $logstash::purge_config,
       recurse => $logstash::purge_config,
       mode    => '0775',
+      notify  => Service['logstash'],
     }
 
     file {     "${logstash::config_dir}/patterns":


### PR DESCRIPTION
Currently when purging config files logstash is not restarted. This adds a notify on the config directory to the logstash service so that it will be restarted on purges.