### PR TITLE
No path.config for centralized pipeline management

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ Note that specifying `pipelines` will automatically remove the default
 `path.config` setting from `logstash.yml`, since this is incompatible with
 `pipelines.yml`.
 
+Enabling centralized pipeline management with `xpack.management.enabled` will
+also remove the default `path.config`.
+
 ### Pipeline Configuration
 Pipeline configuration files can be declared with the `logstash::configfile`
 type.

--- a/spec/acceptance/class_logstash_spec.rb
+++ b/spec/acceptance/class_logstash_spec.rb
@@ -245,4 +245,36 @@ describe 'class logstash' do
       end
     end
   end
+
+  describe 'xpack_management_enabled_parameter' do
+    context 'when set true with dotted notation' do
+      before(:context) do
+        settings_puppet_code = '{"xpack.management.enabled" => true}'
+        install_logstash_from_local_file("settings => #{settings_puppet_code}")
+      end
+
+      it 'should remove "path.config" from "logstash.yml"' do
+        expect(logstash_settings['path.config']).to be_nil
+      end
+    end
+
+    context 'when set true with hierarchical notation' do
+      before(:context) do
+        settings_puppet_code = <<-END
+        {
+          "xpack" => {
+            "management" => {
+              "enabled" => true
+            }
+          }
+        }
+        END
+        install_logstash_from_local_file("settings => #{settings_puppet_code}")
+      end
+
+      it 'should remove "path.config" from "logstash.yml"' do
+        expect(logstash_settings['path.config']).to be_nil
+      end
+    end
+  end
 end

--- a/templates/logstash.yml.erb
+++ b/templates/logstash.yml.erb
@@ -5,4 +5,14 @@
 <%# -%>
 <%# REF: https://github.com/elastic/logstash/issues/8420 -%>
 <% @settings.delete('path.config') unless @pipelines.empty? -%>
+<%# -%>
+<%# Similiarly, when using centralized pipeline management, path.config -%>
+<%# is an invalid setting, and should be removed. -%>
+<%# REF: https://github.com/elastic/puppet-logstash/issues/357 -%>
+<% @settings.delete('path.config') if @settings['xpack.management.enabled'] -%>
+<% begin -%>
+<%     @settings.delete('path.config') if @settings['xpack']['management']['enabled'] -%>
+<% rescue NoMethodError -%>
+<% end -%>
+<%# -%>
 <%= @settings.to_yaml %>


### PR DESCRIPTION
Disable path.config when using x-pack centralized pipeline
management.

Fixes #357