### PR TITLE
Add OracleLinux 6 Service Provider

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -133,8 +133,8 @@ class logstash::service {
   elsif($os == 'debian' and $release == '8') {
     $service_provider = 'systemd'
   }
-  # Centos 6 uses Upstart by default, but Puppet can get confused about this too.
-  elsif($os =~ /(redhat|centos)/ and $release == '6') {
+  # RedHat/CentOS/OEL 6 uses Upstart by default, but Puppet can get confused about this too.
+  elsif($os =~ /(redhat|centos|oraclelinux)/ and $release == '6') {
     $service_provider = 'upstart'
   }
   elsif($os =~ /ubuntu/ and $release == '12.04') {


### PR DESCRIPTION
This updates the service_provider settings in logstash::service to
include 'oraclelinux' with 'centos' and 'redhat' for setting upstart
as the provider. Puppet interprets the service provider incorrectly
for logstash and the service resource fails.