### PR TITLE
Honour `restart_on_change` for startup files

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -111,10 +111,18 @@ class logstash::service {
 
     # Invoke 'system-install', which generates startup scripts based on the
     # contents of the 'startup.options' file.
-    exec { 'logstash-system-install':
-      command     => "${logstash::home_dir}/bin/system-install",
-      refreshonly => true,
-      notify      => Service['logstash'],
+    # Only if restart_on_change is not false
+    if $::logstash::restart_on_change {
+      exec { 'logstash-system-install':
+        command     => "${logstash::home_dir}/bin/system-install",
+        refreshonly => true,
+        notify      => Service['logstash'],
+      }
+    } else {
+      exec { 'logstash-system-install':
+        command     => "${logstash::home_dir}/bin/system-install",
+        refreshonly => true,
+      }
     }
   }
 


### PR DESCRIPTION
Avoid restarting logstash service if restart_on_change is false.