### PR TITLE
RFC: WIP: Pipeline configuration improvements

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,7 +3,5 @@ fixtures:
     apt: puppetlabs/apt
     elastic_stack: elastic/elastic_stack
     stdlib: puppetlabs/stdlib
+    concat: puppetlabs/concat
     zypprepo: darin/zypprepo
-
-symlinks:
-    logstash: #{source_dir}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,7 +151,7 @@ class logstash(
   $settings          = {},
   $startup_options   = {},
   $jvm_options       = [],
-  Array $pipelines   = [],
+  Variant[Boolean,Array[Hash,1]] $pipelines = false,
   Boolean $manage_repo   = true,
 )
 {

--- a/manifests/pipeline.pp
+++ b/manifests/pipeline.pp
@@ -1,0 +1,41 @@
+define logstash::pipeline
+(
+  Hash $config                     = {},
+  Optional[String] $content        = undef,
+  Optional[String] $source         = undef,
+  Optional[Stdlib::Unixpath] $path = undef,
+  Optional[String] $id             = undef,
+)
+{
+  unless $logstash::pipelines { fail('You must set base class `logstash`\'s `pipeline` parameter to `true` to use this defined type.') }
+  if $content and $source { fail('You can\'t specify both `content` and `source`') }
+
+  # overwrite keys in $config with values from $path and $id (if they're set).
+  $real_config = $config + {
+    'pipeline.id' => $id,
+    'path.config' => $path,
+    }.filter |$key, $val| { $val =~ NotUndef }
+
+  unless 'pipeline.id' in $real_config { fail("logstash::pipeline ${title} is missing a pipeline id") }
+
+  $yaml = [$real_config].to_yaml
+  $yaml_without_header = join($yaml.split("\n")[1,-1],"\n")
+
+  concat::fragment { "logstash pipeline ${title}":
+    target  => '/etc/logstash/pipelines.yml',
+    content => "${yaml_without_header}\n",
+  }
+
+  if $content or $source {
+    if 'path.config' in $real_config {
+      $real_path = $real_config['path.config']
+    } else {
+      fail('To use logstash::pipeline with `content` or `source`, the `config` hash must contain a `path.config` key or you must specify `path`')
+    }
+    logstash::configfile { "Config file for pipeline.id ${real_config['pipeline.id']}":
+      content => $content,
+      source  => $source,
+      path    => $real_path,
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,10 @@
       "version_requirement": ">=3.2.0 <6.0.0"
     },
     {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">=4.1.0 <6.0.0"
+    },
+    {
       "name": "elastic/elastic_stack",
       "version_requirement": ">=6.0.0 <7.0.0"
     }

--- a/templates/logstash.yml.erb
+++ b/templates/logstash.yml.erb
@@ -4,7 +4,7 @@
 <%# removing the 'path.config' setting. -%>
 <%# -%>
 <%# REF: https://github.com/elastic/logstash/issues/8420 -%>
-<% @settings.delete('path.config') unless @pipelines.empty? -%>
+<% @settings.delete('path.config') if @pipelines -%>
 <%# -%>
 <%# Similiarly, when using centralized pipeline management, path.config -%>
 <%# is an invalid setting, and should be removed. -%>


### PR DESCRIPTION
This isn't finished.  If it looks like I'm going in the right direction (or can be steered that way!), I still have to add docs, examples and tests etc.  Hopefully there's enough here for some early feedback. :)

I wanted a way that I could add extra pipelines without having to modify the `pipelines` parameter passed to the base class each time.

This adds a defined type for adding pipelines and uses concat to write the pipelines.yml file.  If you specify a `content` or `source` it'll also create the `logstash::configfile` to the right file (`path.config`).

It aims to be backwards compatible. (An array of pipeline configs will still be written to the pipelines.yml as before).