### PR TITLE
Closes #338

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,37 @@ my_logstash_configs:
 In this example, templates for the config files are stored in the custom,
 site-specific module "`site_logstash`".
 
+You can also use the `pipeline_files` class within an ENC to generate pipeline configuration files:
+
+```yaml
+---
+pipeline1:
+  content: 'input {} filter {} output {}'
+```
+
+Or, with a specific destination file path:
+
+```yaml
+---
+pipeline2:
+  path: /etc/logstash/pipelines.d/pipeline2.pipeline
+  content: 'input {} filter {} output {}'
+```
+
+`content` can also span multiple lines:
+
+```yaml
+---
+pipeline2.pipeline:
+  content: |
+    input {
+      syslog {}
+    }
+    output {
+      elasticsearch {}
+    }
+```
+
 ### Patterns
 Many plugins (notably [Grok](http://logstash.net/docs/latest/filters/grok)) use *patterns*. While many are included in Logstash already, additional site-specific patterns can be managed as well.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,6 +152,7 @@ class logstash(
   $startup_options   = {},
   $jvm_options       = [],
   Array $pipelines   = [],
+  Hash $pipeline_files = {},
   Boolean $manage_repo   = true,
 )
 {
@@ -171,4 +172,5 @@ class logstash(
   include logstash::package
   include logstash::config
   include logstash::service
+  include logstash::pipeline_files
 }

--- a/manifests/pipeline_files.pp
+++ b/manifests/pipeline_files.pp
@@ -1,0 +1,29 @@
+# This class manages pipeline configuration files for Logstash.
+#
+# @example Include this class to ensure its resources are available.
+#   include logstash::pipeline_files
+#
+# @example Pass values to this class using an ENC with a specific path
+#   pipeline2:
+#     path: "/etc/logstash/conf.d/pipeline2.pipeline"
+#     content: pipeline2
+#
+# @example Pass values to this class using an ENC without a specific path
+#   pipeline2:
+#     content: pipeline2
+#
+# @author https://github.com/XeonFibre
+#
+class logstash::pipeline_files {
+
+  $pipeline_files = $logstash::pipeline_files
+
+  if(!empty($pipeline_files)) {
+    $pipeline_files.each |String $id, Hash $attributes| {
+      logstash::configfile { $id:
+        content => $attributes[content],
+        path    => $attributes[path],
+      }
+    }
+  }
+}

--- a/spec/acceptance/class_logstash_spec.rb
+++ b/spec/acceptance/class_logstash_spec.rb
@@ -263,6 +263,47 @@ describe 'class logstash' do
     end
   end
 
+  describe 'pipeline_files_parameter' do
+    context "with specific config path declared" do
+      before(:context) do
+        pipeline_files_puppet = <<-END
+        { "logstash-pipeline1.conf" =>
+          {
+            "path" => "/etc/logstash/conf.d/logstash-pipeline1.conf",
+            "content" => "My config"
+          }
+        }
+        END
+        install_logstash_from_local_file("pipeline_files => #{pipeline_files_puppet}")
+      end
+
+      it 'should render them to /etc/logstash/conf.d/logstash-pipeline1.conf' do
+        result = shell('cat /etc/logstash/conf.d/logstash-pipeline1.conf').stdout
+        expect(result).to eq("My config")
+      end
+
+    end
+
+    context "without specific config path declared" do
+      before(:context) do
+        pipeline_files_puppet = <<-END
+        { "logstash-pipeline2.conf" =>
+          {
+            "content" => "My config"
+          }
+        }
+        END
+        install_logstash_from_local_file("pipeline_files => #{pipeline_files_puppet}")
+      end
+
+      it 'should render them to /etc/logstash/conf.d/logstash-pipeline2.conf' do
+        result = shell('cat /etc/logstash/conf.d/logstash-pipeline2.conf').stdout
+        expect(result).to eq("My config")
+      end
+
+    end
+  end
+
   describe 'xpack_management_enabled_parameter' do
     context 'when set true with dotted notation' do
       before(:context) do


### PR DESCRIPTION
Wrote a wrapper class to call the configfile defined type.  Spec tests have also been written for the new functionality.  README.md updated with usage examples.

Rspec tests complete successfully and Beaker tests complete successfully on nodesets CentOS 6+7.  The Beaker tests do not start to run on the other nodesets with errors such as: "Couldn't find id: {"stream":"Step 1/18 : FROM library/ubuntu:16.04"}"